### PR TITLE
fix: prevent replay attacks in Django trust middleware

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -101,7 +101,10 @@
     "pwsh",
     "notlike",
     "sdists",
-    "shellcheck"
+    "shellcheck",
+    "binascii",
+    "locmem",
+    "altchars"
   ],
   "ignorePaths": [
     "**/node_modules/**",

--- a/.cspell.json
+++ b/.cspell.json
@@ -104,7 +104,8 @@
     "shellcheck",
     "binascii",
     "locmem",
-    "altchars"
+    "altchars",
+    "filebased"
   ],
   "ignorePaths": [
     "**/node_modules/**",

--- a/agent-governance-python/agent-mesh/README.md
+++ b/agent-governance-python/agent-mesh/README.md
@@ -335,6 +335,7 @@ pip install -e .
 
 **Framework integrations:**
 - **[Claude Desktop](./docs/integrations/claude-desktop.md)** - Secure MCP tools with one command
+- [Django](./docs/integrations/django-middleware.md) - Replay-protected, request-bound Ed25519 authentication
 - [LangChain Integration](./examples/integrations/langchain.md) - Secure LangChain agents with policies
 - [CrewAI Integration](./examples/integrations/crewai.md) - Multi-agent crew governance
 - [LangGraph](./src/agentmesh/integrations/langgraph/) - Trust checkpoints for graph workflows (built-in)

--- a/agent-governance-python/agent-mesh/docs/integrations/django-middleware.md
+++ b/agent-governance-python/agent-mesh/docs/integrations/django-middleware.md
@@ -10,8 +10,8 @@ pip install "agent-governance-toolkit-core[django,redis]"
 
 ## Server Configuration
 
-Configure a cache shared by every Django worker and replica. The cache backend must implement
-atomic `add()` semantics so that only one request can claim a nonce.
+Configure Django's `RedisCache` or a shared memcached backend across every worker and replica.
+These backends provide atomic `add()` semantics so that only one request can claim a nonce.
 
 ```python
 CACHES = {
@@ -24,6 +24,7 @@ CACHES = {
 AGENTMESH_AUDIENCE = "billing-api"
 AGENTMESH_REPLAY_CACHE_ALIAS = "agentmesh_replay"
 AGENTMESH_REPLAY_WINDOW_SECONDS = 300
+AGENTMESH_MAX_SIGNED_BODY_BYTES = 2_621_440
 AGENTMESH_AGENT_KEYS = {
     "did:mesh:alice": alice_ed25519_public_key,
 }
@@ -34,9 +35,15 @@ MIDDLEWARE = [
 ]
 ```
 
-The middleware refuses to start with Django's local-memory cache because that backend cannot
-detect replay across processes. Tests and single-process development servers can explicitly set
+The middleware fails closed at startup for unsupported backends, including dummy, file-based,
+database, and custom caches whose shared atomic nonce claims cannot be guaranteed. It also refuses
+to start with Django's local-memory cache because that backend cannot detect replay across
+processes. Tests and single-process development servers can explicitly set
 `AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE = True`; do not enable this setting in production.
+
+Signed request bodies are limited to `AGENTMESH_MAX_SIGNED_BODY_BYTES` (2.5 MiB by default). The
+middleware enforces the limit while reading the stream, including when `Content-Length` is absent
+or understated.
 
 ## Signing Requests
 

--- a/agent-governance-python/agent-mesh/docs/integrations/django-middleware.md
+++ b/agent-governance-python/agent-mesh/docs/integrations/django-middleware.md
@@ -1,0 +1,95 @@
+# Django Trust Middleware
+
+`AgentTrustMiddleware` authenticates each request with an Ed25519 signature bound to the
+request contents and rejects reused nonces. Install the Django optional dependency before using
+the integration:
+
+```bash
+pip install "agent-governance-toolkit-core[django,redis]"
+```
+
+## Server Configuration
+
+Configure a cache shared by every Django worker and replica. The cache backend must implement
+atomic `add()` semantics so that only one request can claim a nonce.
+
+```python
+CACHES = {
+    "agentmesh_replay": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": "redis://redis:6379/2",
+    }
+}
+
+AGENTMESH_AUDIENCE = "billing-api"
+AGENTMESH_REPLAY_CACHE_ALIAS = "agentmesh_replay"
+AGENTMESH_REPLAY_WINDOW_SECONDS = 300
+AGENTMESH_AGENT_KEYS = {
+    "did:mesh:alice": alice_ed25519_public_key,
+}
+
+MIDDLEWARE = [
+    "agentmesh.integrations.django_middleware.middleware.AgentTrustMiddleware",
+    # Other middleware...
+]
+```
+
+The middleware refuses to start with Django's local-memory cache because that backend cannot
+detect replay across processes. Tests and single-process development servers can explicitly set
+`AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE = True`; do not enable this setting in production.
+
+## Signing Requests
+
+Every authenticated request requires these headers:
+
+| Header | Value |
+|--------|-------|
+| `X-Agent-DID` | DID registered in `AGENTMESH_AGENT_KEYS` |
+| `X-Agent-Timestamp` | Timezone-aware ISO-8601 timestamp within the replay window |
+| `X-Agent-Nonce` | Unique base64url value containing 16 to 64 random bytes |
+| `X-Agent-Signature` | Base64-encoded Ed25519 signature of the canonical request payload |
+
+Use `build_request_signature_payload` to produce the canonical bytes. The path must include the
+query string in its transmitted order, and `body` must contain the exact bytes sent on the wire.
+
+```python
+import base64
+import secrets
+from datetime import datetime, timezone
+
+from agentmesh.integrations.django_middleware import build_request_signature_payload
+
+agent_did = "did:mesh:alice"
+audience = "billing-api"
+timestamp = datetime.now(timezone.utc).isoformat()
+nonce = secrets.token_urlsafe(16)
+body = b'{"amount":100,"currency":"USD"}'
+content_type = "application/json"
+
+payload = build_request_signature_payload(
+    agent_did=agent_did,
+    audience=audience,
+    timestamp=timestamp,
+    nonce=nonce,
+    method="POST",
+    request_target="/v1/payments?mode=immediate",
+    body=body,
+    content_type=content_type,
+)
+signature = base64.b64encode(private_key.sign(payload)).decode("ascii")
+
+headers = {
+    "Content-Type": content_type,
+    "X-Agent-DID": agent_did,
+    "X-Agent-Timestamp": timestamp,
+    "X-Agent-Nonce": nonce,
+    "X-Agent-Signature": signature,
+}
+```
+
+The signed envelope binds the DID, configured audience, timestamp, nonce, HTTP method, path and
+query, content type, and SHA-256 body digest. Changing any of these values invalidates the
+signature. A correctly signed nonce is accepted once and retained in the replay cache for the
+configured replay window. Cache errors fail closed.
+
+Signatures over only the agent DID are not accepted.

--- a/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/__init__.py
@@ -13,11 +13,13 @@ at instantiation time instead.
 from __future__ import annotations
 
 try:
+    from .decorators import trust_exempt, trust_required
     from .middleware import AgentTrustMiddleware
-    from .decorators import trust_required, trust_exempt
+    from .request_auth import build_request_signature_payload
 
     __all__ = [
         "AgentTrustMiddleware",
+        "build_request_signature_payload",
         "trust_required",
         "trust_exempt",
     ]

--- a/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/middleware.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/middleware.py
@@ -17,11 +17,14 @@ import logging
 import math
 from collections.abc import Callable
 from datetime import UTC, datetime
+from io import BytesIO
 from typing import Any
 
 from django.conf import settings
 from django.core.cache import InvalidCacheBackendError, caches
 from django.core.cache.backends.locmem import LocMemCache
+from django.core.cache.backends.memcached import BaseMemcachedCache
+from django.core.cache.backends.redis import RedisCache
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse, JsonResponse
 
@@ -64,6 +67,8 @@ class AgentTrustMiddleware:
             atomic replay detection
         - ``AGENTMESH_REPLAY_WINDOW_SECONDS`` — accepted timestamp window and
             replay-cache lifetime (default 300)
+        - ``AGENTMESH_MAX_SIGNED_BODY_BYTES`` — maximum request body size covered
+            by signature verification (default 2.5 MiB)
     - ``AGENTMESH_EXEMPT_PATHS`` — list of URL path prefixes that skip
       trust verification (default ``[]``)
 
@@ -77,6 +82,8 @@ class AgentTrustMiddleware:
             raise ImproperlyConfigured("AGENTMESH_AUDIENCE must identify this service")
         if self._replay_window_seconds() <= 0:
             raise ImproperlyConfigured("AGENTMESH_REPLAY_WINDOW_SECONDS must be positive")
+        if self._max_signed_body_bytes() <= 0:
+            raise ImproperlyConfigured("AGENTMESH_MAX_SIGNED_BODY_BYTES must be positive")
         cache_alias = str(_get_setting("AGENTMESH_REPLAY_CACHE_ALIAS", "")).strip()
         if not cache_alias:
             raise ImproperlyConfigured(
@@ -88,13 +95,17 @@ class AgentTrustMiddleware:
             raise ImproperlyConfigured(
                 f"AGENTMESH_REPLAY_CACHE_ALIAS references an invalid cache: {cache_alias}"
             ) from exc
-        if isinstance(self._replay_cache, LocMemCache) and not bool(
-            _get_setting("AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE", False)
-        ):
+        if isinstance(self._replay_cache, LocMemCache):
+            if _get_setting("AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE", False) is not True:
+                raise ImproperlyConfigured(
+                    "The local-memory cache cannot prevent replay across workers; configure a "
+                    "shared AGENTMESH_REPLAY_CACHE_ALIAS or explicitly set "
+                    "AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE=True for development"
+                )
+        elif not isinstance(self._replay_cache, (RedisCache, BaseMemcachedCache)):
             raise ImproperlyConfigured(
-                "The local-memory cache cannot prevent replay across workers; configure a shared "
-                "AGENTMESH_REPLAY_CACHE_ALIAS or explicitly set "
-                "AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE=True for development"
+                "AGENTMESH_REPLAY_CACHE_ALIAS must use Django's RedisCache or a shared memcached "
+                "backend with atomic add() semantics"
             )
 
     # ------------------------------------------------------------------
@@ -124,6 +135,10 @@ class AgentTrustMiddleware:
     @staticmethod
     def _replay_window_seconds() -> int:
         return int(_get_setting("AGENTMESH_REPLAY_WINDOW_SECONDS", 300))
+
+    @staticmethod
+    def _max_signed_body_bytes() -> int:
+        return int(_get_setting("AGENTMESH_MAX_SIGNED_BODY_BYTES", 2_621_440))
 
     @staticmethod
     def _exempt_paths() -> list[str]:
@@ -277,17 +292,8 @@ class AgentTrustMiddleware:
             return 0
         if timestamp.tzinfo is None:
             return 0
-        now = _utcnow()
-        age_seconds = abs((now - timestamp).total_seconds())
-        if age_seconds > replay_window:
+        if abs((_utcnow() - timestamp).total_seconds()) > replay_window:
             return 0
-
-        # Retain the nonce until the signed timestamp's complete validity
-        # interval ends, including any accepted future clock skew.
-        replay_timeout = max(
-            1,
-            math.ceil((timestamp - now).total_seconds() + replay_window),
-        )
 
         if len(agent_nonce) > 128:
             return 0
@@ -313,6 +319,9 @@ class AgentTrustMiddleware:
             request_target = request.path
             if query_string:
                 request_target = f"{request_target}?{query_string}"
+            body = self._read_request_body(request)
+            if body is None:
+                return 0
             payload = build_request_signature_payload(
                 agent_did=agent_did,
                 audience=audience,
@@ -320,13 +329,25 @@ class AgentTrustMiddleware:
                 nonce=agent_nonce,
                 method=request.method,
                 request_target=request_target,
-                body=request.body,
+                body=body,
                 content_type=request.META.get("CONTENT_TYPE", ""),
             )
             public_key.verify(sig_bytes, payload)
         except Exception:
             logger.warning("Signature verification failed for agent %s", agent_did)
             return 0
+
+        now = _utcnow()
+        age_seconds = abs((now - timestamp).total_seconds())
+        if age_seconds > replay_window:
+            return 0
+
+        # Retain the nonce until the signed timestamp's complete validity
+        # interval ends, including any accepted future clock skew.
+        replay_timeout = max(
+            1,
+            math.ceil((timestamp - now).total_seconds() + replay_window),
+        )
 
         replay_key_material = agent_did.encode("utf-8") + b"\0" + nonce_bytes
         replay_key = "agentmesh:request-nonce:" + hashlib.sha256(replay_key_material).hexdigest()
@@ -337,7 +358,33 @@ class AgentTrustMiddleware:
         except Exception:
             logger.exception("Replay cache failure while verifying agent %s", agent_did)
             return 0
+        if abs((_utcnow() - timestamp).total_seconds()) > replay_window:
+            return 0
         return 750
+
+    def _read_request_body(self, request: HttpRequest) -> bytes | None:
+        max_body_bytes = self._max_signed_body_bytes()
+        content_length = request.META.get("CONTENT_LENGTH")
+        if content_length:
+            try:
+                if int(content_length) > max_body_bytes:
+                    return None
+            except (TypeError, ValueError):
+                return None
+
+        if hasattr(request, "_body"):
+            body = request.body
+            return body if len(body) <= max_body_bytes else None
+        if request._read_started:
+            return None
+
+        body = request.read(max_body_bytes + 1)
+        request._stream.close()
+        if len(body) > max_body_bytes:
+            return None
+        request._body = body
+        request._stream = BytesIO(body)
+        return body
 
     @staticmethod
     def _resolve_view_func(request: HttpRequest) -> Callable[..., Any] | None:

--- a/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/middleware.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/middleware.py
@@ -10,12 +10,21 @@ Configurable via Django settings; returns 403 JSON on trust failure.
 
 from __future__ import annotations
 
+import base64
+import binascii
+import hashlib
 import logging
-from typing import Any, Callable, List, Optional
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
 
 from django.conf import settings
+from django.core.cache import InvalidCacheBackendError, caches
+from django.core.cache.backends.locmem import LocMemCache
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse, JsonResponse
 
+from .request_auth import build_request_signature_payload
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +49,16 @@ class AgentTrustMiddleware:
       (default ``"X-Agent-DID"``)
     - ``AGENTMESH_SIGNATURE_HEADER`` — request header carrying the agent
       signature (default ``"X-Agent-Signature"``)
+        - ``AGENTMESH_TIMESTAMP_HEADER`` — request header carrying the signed
+            ISO-8601 timestamp (default ``"X-Agent-Timestamp"``)
+        - ``AGENTMESH_NONCE_HEADER`` — request header carrying a unique, random
+            base64url nonce (default ``"X-Agent-Nonce"``)
+        - ``AGENTMESH_AUDIENCE`` — required service identifier covered by the
+            request signature
+        - ``AGENTMESH_REPLAY_CACHE_ALIAS`` — required Django cache alias used for
+            atomic replay detection
+        - ``AGENTMESH_REPLAY_WINDOW_SECONDS`` — accepted timestamp window and
+            replay-cache lifetime (default 300)
     - ``AGENTMESH_EXEMPT_PATHS`` — list of URL path prefixes that skip
       trust verification (default ``[]``)
 
@@ -49,6 +68,29 @@ class AgentTrustMiddleware:
 
     def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
         self.get_response = get_response
+        if not str(_get_setting("AGENTMESH_AUDIENCE", "")).strip():
+            raise ImproperlyConfigured("AGENTMESH_AUDIENCE must identify this service")
+        if self._replay_window_seconds() <= 0:
+            raise ImproperlyConfigured("AGENTMESH_REPLAY_WINDOW_SECONDS must be positive")
+        cache_alias = str(_get_setting("AGENTMESH_REPLAY_CACHE_ALIAS", "")).strip()
+        if not cache_alias:
+            raise ImproperlyConfigured(
+                "AGENTMESH_REPLAY_CACHE_ALIAS must name a shared Django cache backend"
+            )
+        try:
+            self._replay_cache = caches[cache_alias]
+        except InvalidCacheBackendError as exc:
+            raise ImproperlyConfigured(
+                f"AGENTMESH_REPLAY_CACHE_ALIAS references an invalid cache: {cache_alias}"
+            ) from exc
+        if isinstance(self._replay_cache, LocMemCache) and not bool(
+            _get_setting("AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE", False)
+        ):
+            raise ImproperlyConfigured(
+                "The local-memory cache cannot prevent replay across workers; configure a shared "
+                "AGENTMESH_REPLAY_CACHE_ALIAS or explicitly set "
+                "AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE=True for development"
+            )
 
     # ------------------------------------------------------------------
     # helpers
@@ -67,11 +109,23 @@ class AgentTrustMiddleware:
         return str(_get_setting("AGENTMESH_SIGNATURE_HEADER", "X-Agent-Signature"))
 
     @staticmethod
-    def _exempt_paths() -> List[str]:
+    def _timestamp_header() -> str:
+        return str(_get_setting("AGENTMESH_TIMESTAMP_HEADER", "X-Agent-Timestamp"))
+
+    @staticmethod
+    def _nonce_header() -> str:
+        return str(_get_setting("AGENTMESH_NONCE_HEADER", "X-Agent-Nonce"))
+
+    @staticmethod
+    def _replay_window_seconds() -> int:
+        return int(_get_setting("AGENTMESH_REPLAY_WINDOW_SECONDS", 300))
+
+    @staticmethod
+    def _exempt_paths() -> list[str]:
         return list(_get_setting("AGENTMESH_EXEMPT_PATHS", []))
 
     @staticmethod
-    def _trusted_proxies() -> List[str]:
+    def _trusted_proxies() -> list[str]:
         """Return list of trusted proxy IPs/CIDRs.
 
         When set, DID headers are only trusted from these source IPs.
@@ -106,6 +160,8 @@ class AgentTrustMiddleware:
 
         did_header = self._did_header()
         sig_header = self._signature_header()
+        timestamp_header = self._timestamp_header()
+        nonce_header = self._nonce_header()
 
         # Django normalises headers to META keys: HTTP_X_AGENT_DID
         agent_did: str = request.META.get(
@@ -113,6 +169,12 @@ class AgentTrustMiddleware:
         )
         agent_sig: str = request.META.get(
             "HTTP_" + sig_header.upper().replace("-", "_"), ""
+        )
+        agent_timestamp: str = request.META.get(
+            "HTTP_" + timestamp_header.upper().replace("-", "_"), ""
+        )
+        agent_nonce: str = request.META.get(
+            "HTTP_" + nonce_header.upper().replace("-", "_"), ""
         )
 
         if not agent_did:
@@ -132,7 +194,7 @@ class AgentTrustMiddleware:
             request.agent_trust_score = None  # type: ignore[attr-defined]
             return self.get_response(request)
 
-        per_view_score: Optional[int] = None
+        per_view_score: int | None = None
         if view_func is not None:
             per_view_score = getattr(view_func, _TRUST_REQUIRED_ATTR, None)
 
@@ -141,7 +203,13 @@ class AgentTrustMiddleware:
         # Derive trust score — simple heuristic:
         # agents that provide a valid DID get a baseline score; agents that
         # also provide a signature get a higher score.
-        trust_score = self._evaluate_trust(agent_did, agent_sig)
+        trust_score = self._evaluate_trust(
+            request,
+            agent_did,
+            agent_sig,
+            agent_timestamp,
+            agent_nonce,
+        )
 
         if trust_score < min_score:
             logger.warning(
@@ -164,20 +232,58 @@ class AgentTrustMiddleware:
     # internal
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _evaluate_trust(agent_did: str, agent_sig: str) -> int:
+    def _evaluate_trust(
+        self,
+        request: HttpRequest,
+        agent_did: str,
+        agent_sig: str,
+        agent_timestamp: str,
+        agent_nonce: str,
+    ) -> int:
         """Return trust score for the given agent.
 
-        Verifies the agent's Ed25519 signature over its DID.  The agent
-        must sign the DID string with its private key and send the
-        base64-encoded signature in the signature header.
+        Verifies an Ed25519 signature over a versioned envelope binding the
+        agent identity, audience, freshness values, and HTTP request.
 
         The verifying public key is looked up via the Django setting
         ``AGENTMESH_AGENT_KEYS``, a dict mapping DID → Ed25519PublicKey.
         Agents not in the registry or with invalid signatures receive a
         score of 0.
         """
-        if not agent_did or not agent_sig:
+        if not all((agent_did, agent_sig, agent_timestamp, agent_nonce)):
+            return 0
+
+        audience = str(_get_setting("AGENTMESH_AUDIENCE", "")).strip()
+        if not audience:
+            logger.error("AGENTMESH_AUDIENCE is required for request verification")
+            return 0
+
+        replay_window = self._replay_window_seconds()
+        if replay_window <= 0 or len(agent_timestamp) > 64:
+            return 0
+        timestamp_value = (
+            agent_timestamp[:-1] + "+00:00"
+            if agent_timestamp.endswith("Z")
+            else agent_timestamp
+        )
+        try:
+            timestamp = datetime.fromisoformat(timestamp_value)
+        except ValueError:
+            return 0
+        if timestamp.tzinfo is None:
+            return 0
+        age_seconds = abs((datetime.now(UTC) - timestamp).total_seconds())
+        if age_seconds > replay_window:
+            return 0
+
+        if len(agent_nonce) > 128:
+            return 0
+        try:
+            padded_nonce = agent_nonce + "=" * (-len(agent_nonce) % 4)
+            nonce_bytes = base64.b64decode(padded_nonce, altchars=b"-_", validate=True)
+        except (ValueError, binascii.Error):
+            return 0
+        if not 16 <= len(nonce_bytes) <= 64:
             return 0
 
         agent_keys: dict = _get_setting("AGENTMESH_AGENT_KEYS", {})
@@ -186,19 +292,44 @@ class AgentTrustMiddleware:
             logger.warning("No public key registered for agent %s", agent_did)
             return 0
 
-        import base64
         try:
-            sig_bytes = base64.b64decode(agent_sig)
-            public_key.verify(sig_bytes, agent_did.encode("utf-8"))
-            return 750
+            sig_bytes = base64.b64decode(agent_sig, validate=True)
+            if len(sig_bytes) != 64:
+                return 0
+            query_string = request.META.get("QUERY_STRING", "")
+            request_target = request.path
+            if query_string:
+                request_target = f"{request_target}?{query_string}"
+            payload = build_request_signature_payload(
+                agent_did=agent_did,
+                audience=audience,
+                timestamp=agent_timestamp,
+                nonce=agent_nonce,
+                method=request.method,
+                request_target=request_target,
+                body=request.body,
+                content_type=request.META.get("CONTENT_TYPE", ""),
+            )
+            public_key.verify(sig_bytes, payload)
         except Exception:
             logger.warning("Signature verification failed for agent %s", agent_did)
             return 0
 
+        replay_key_material = agent_did.encode("utf-8") + b"\0" + nonce_bytes
+        replay_key = "agentmesh:request-nonce:" + hashlib.sha256(replay_key_material).hexdigest()
+        try:
+            if not self._replay_cache.add(replay_key, True, timeout=replay_window):
+                logger.warning("Replay detected for agent %s", agent_did)
+                return 0
+        except Exception:
+            logger.exception("Replay cache failure while verifying agent %s", agent_did)
+            return 0
+        return 750
+
     @staticmethod
-    def _resolve_view_func(request: HttpRequest) -> Optional[Callable[..., Any]]:
+    def _resolve_view_func(request: HttpRequest) -> Callable[..., Any] | None:
         """Resolve the view function for the current request, if possible."""
-        from django.urls import resolve, Resolver404
+        from django.urls import Resolver404, resolve
 
         try:
             match = resolve(request.path)

--- a/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/middleware.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/middleware.py
@@ -14,6 +14,7 @@ import base64
 import binascii
 import hashlib
 import logging
+import math
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
@@ -37,6 +38,10 @@ _TRUST_REQUIRED_ATTR = "_agentmesh_min_trust_score"
 def _get_setting(name: str, default: Any) -> Any:
     """Read a Django setting with a fallback default."""
     return getattr(settings, name, default)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
 
 
 class AgentTrustMiddleware:
@@ -272,9 +277,17 @@ class AgentTrustMiddleware:
             return 0
         if timestamp.tzinfo is None:
             return 0
-        age_seconds = abs((datetime.now(UTC) - timestamp).total_seconds())
+        now = _utcnow()
+        age_seconds = abs((now - timestamp).total_seconds())
         if age_seconds > replay_window:
             return 0
+
+        # Retain the nonce until the signed timestamp's complete validity
+        # interval ends, including any accepted future clock skew.
+        replay_timeout = max(
+            1,
+            math.ceil((timestamp - now).total_seconds() + replay_window),
+        )
 
         if len(agent_nonce) > 128:
             return 0
@@ -318,7 +331,7 @@ class AgentTrustMiddleware:
         replay_key_material = agent_did.encode("utf-8") + b"\0" + nonce_bytes
         replay_key = "agentmesh:request-nonce:" + hashlib.sha256(replay_key_material).hexdigest()
         try:
-            if not self._replay_cache.add(replay_key, True, timeout=replay_window):
+            if not self._replay_cache.add(replay_key, True, timeout=replay_timeout):
                 logger.warning("Replay detected for agent %s", agent_did)
                 return 0
         except Exception:

--- a/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/request_auth.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/integrations/django_middleware/request_auth.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Canonical request authentication payloads for the Django integration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+REQUEST_SIGNATURE_VERSION = "agentmesh-http-request-v1"
+
+
+def build_request_signature_payload(
+    *,
+    agent_did: str,
+    audience: str,
+    timestamp: str,
+    nonce: str,
+    method: str,
+    request_target: str,
+    body: bytes,
+    content_type: str = "",
+) -> bytes:
+    """Build the canonical bytes covered by an AgentMesh HTTP signature."""
+    envelope = {
+        "agent_did": agent_did,
+        "audience": audience,
+        "body_sha256": hashlib.sha256(body).hexdigest(),
+        "content_type": content_type,
+        "method": method.upper(),
+        "nonce": nonce,
+        "request_target": request_target,
+        "timestamp": timestamp,
+    }
+    canonical_json = json.dumps(envelope, sort_keys=True, separators=(",", ":"))
+    return f"{REQUEST_SIGNATURE_VERSION}\n{canonical_json}".encode()

--- a/agent-governance-python/agent-mesh/tests/test_django_middleware.py
+++ b/agent-governance-python/agent-mesh/tests/test_django_middleware.py
@@ -55,6 +55,7 @@ from agentmesh.integrations.django_middleware import (  # noqa: E402
     trust_exempt,
     trust_required,
 )
+from agentmesh.integrations.django_middleware import middleware as middleware_module  # noqa: E402
 
 # ── Dummy views & URL configuration ─────────────────────────────────
 
@@ -298,6 +299,33 @@ class TestAgentTrustMiddleware:
 
             assert mw(original).status_code == 200
             assert mw(replay).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    def test_future_timestamp_nonce_is_cached_until_signature_expires(self, monkeypatch):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        now = datetime(2026, 8, 18, 12, 0, tzinfo=UTC)
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:future-replay"
+        timestamp = (now + timedelta(seconds=299)).isoformat()
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            mw = _make_middleware()
+            original_add = mw._replay_cache.add
+            observed_timeout = None
+
+            def _recording_add(key, value, timeout=None, version=None):
+                nonlocal observed_timeout
+                observed_timeout = timeout
+                return original_add(key, value, timeout=timeout, version=version)
+
+            monkeypatch.setattr(middleware_module, "_utcnow", lambda: now)
+            monkeypatch.setattr(mw._replay_cache, "add", _recording_add)
+
+            request = _signed_request(private_key, agent_did, timestamp=timestamp)
+            assert mw(request).status_code == 200
+            assert observed_timeout == 599
         finally:
             del settings.AGENTMESH_AGENT_KEYS
 

--- a/agent-governance-python/agent-mesh/tests/test_django_middleware.py
+++ b/agent-governance-python/agent-mesh/tests/test_django_middleware.py
@@ -44,6 +44,8 @@ import django as _django  # noqa: E402
 _django.setup()
 
 from django.core.cache import caches  # noqa: E402
+from django.core.cache.backends.dummy import DummyCache  # noqa: E402
+from django.core.cache.backends.filebased import FileBasedCache  # noqa: E402
 from django.core.exceptions import ImproperlyConfigured  # noqa: E402
 from django.http import HttpResponse, JsonResponse  # noqa: E402
 from django.test import RequestFactory  # noqa: E402
@@ -302,6 +304,40 @@ class TestAgentTrustMiddleware:
         finally:
             del settings.AGENTMESH_AGENT_KEYS
 
+    def test_concurrent_replayed_requests_accept_only_one(self, monkeypatch):
+        from concurrent.futures import ThreadPoolExecutor
+        from threading import Barrier
+
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:concurrent-replay"
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            mw = _make_middleware()
+            original = _signed_request(private_key, agent_did)
+            headers = {
+                key: value
+                for key, value in original.META.items()
+                if key.startswith("HTTP_X_AGENT_")
+            }
+            requests = [RequestFactory().get("/api/data/", **headers) for _ in range(2)]
+            barrier = Barrier(2)
+            original_add = mw._replay_cache.add
+
+            def _simultaneous_add(*args, **kwargs):
+                barrier.wait(timeout=5)
+                return original_add(*args, **kwargs)
+
+            monkeypatch.setattr(mw._replay_cache, "add", _simultaneous_add)
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                statuses = list(executor.map(lambda request: mw(request).status_code, requests))
+
+            assert sorted(statuses) == [200, 403]
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
     def test_future_timestamp_nonce_is_cached_until_signature_expires(self, monkeypatch):
         from cryptography.hazmat.primitives.asymmetric import ed25519
 
@@ -326,6 +362,115 @@ class TestAgentTrustMiddleware:
             request = _signed_request(private_key, agent_did, timestamp=timestamp)
             assert mw(request).status_code == 200
             assert observed_timeout == 599
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    def test_timestamp_expiring_while_body_is_read_is_rejected(self, monkeypatch):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        signed_at = datetime(2026, 8, 18, 12, 0, tzinfo=UTC)
+        current_time = signed_at
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:slow-replay"
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            request = _signed_request(
+                private_key,
+                agent_did,
+                method="POST",
+                body=b"delayed body",
+                timestamp=signed_at.isoformat(),
+            )
+            request_read = request.read
+
+            def _delayed_read(*args, **kwargs):
+                nonlocal current_time
+                current_time = signed_at + timedelta(seconds=301)
+                return request_read(*args, **kwargs)
+
+            monkeypatch.setattr(request, "read", _delayed_read)
+            monkeypatch.setattr(middleware_module, "_utcnow", lambda: current_time)
+
+            assert _make_middleware()(request).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    def test_timestamp_expiring_while_nonce_is_claimed_is_rejected(self, monkeypatch):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        signed_at = datetime(2026, 8, 18, 12, 0, tzinfo=UTC)
+        current_time = signed_at
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:slow-cache"
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            mw = _make_middleware()
+            original_add = mw._replay_cache.add
+
+            def _delayed_add(*args, **kwargs):
+                nonlocal current_time
+                result = original_add(*args, **kwargs)
+                current_time = signed_at + timedelta(seconds=301)
+                return result
+
+            monkeypatch.setattr(middleware_module, "_utcnow", lambda: current_time)
+            monkeypatch.setattr(mw._replay_cache, "add", _delayed_add)
+            request = _signed_request(
+                private_key,
+                agent_did,
+                timestamp=signed_at.isoformat(),
+            )
+
+            assert mw(request).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    @pytest.mark.parametrize("include_content_length", [True, False])
+    def test_oversized_signed_body_is_rejected(self, include_content_length):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:oversized-body"
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        settings.AGENTMESH_MAX_SIGNED_BODY_BYTES = 4
+        try:
+            request = _signed_request(
+                private_key,
+                agent_did,
+                method="POST",
+                body=b"12345",
+            )
+            if not include_content_length:
+                request.META.pop("CONTENT_LENGTH", None)
+
+            assert _make_middleware()(request).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+            del settings.AGENTMESH_MAX_SIGNED_BODY_BYTES
+
+    def test_signed_body_remains_available_to_view(self):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:body-preserved"
+        body = b"signed body"
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+
+        def _body_view(request):
+            return HttpResponse(request.body)
+
+        try:
+            request = _signed_request(
+                private_key,
+                agent_did,
+                method="POST",
+                body=body,
+            )
+
+            response = _make_middleware(get_response=_body_view)(request)
+
+            assert response.status_code == 200
+            assert response.content == body
         finally:
             del settings.AGENTMESH_AGENT_KEYS
 
@@ -462,6 +607,30 @@ class TestAgentTrustMiddleware:
         finally:
             settings.AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE = True
 
+    @pytest.mark.parametrize("opt_in", ["True", "False", 1])
+    def test_local_replay_cache_requires_literal_boolean_opt_in(self, opt_in):
+        settings.AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE = opt_in
+        try:
+            with pytest.raises(ImproperlyConfigured, match="cannot prevent replay"):
+                _make_middleware()
+        finally:
+            settings.AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE = True
+
+    @pytest.mark.parametrize("backend_type", [DummyCache, FileBasedCache])
+    def test_unsupported_replay_cache_backend_fails_at_startup(
+        self, backend_type, monkeypatch, tmp_path
+    ):
+        cache_alias = "unsupported-replay-cache"
+        location = str(tmp_path) if backend_type is FileBasedCache else "unused"
+        backend = backend_type(location, {})
+        monkeypatch.setattr(middleware_module, "caches", {cache_alias: backend})
+        settings.AGENTMESH_REPLAY_CACHE_ALIAS = cache_alias
+        try:
+            with pytest.raises(ImproperlyConfigured, match="RedisCache or a shared memcached"):
+                _make_middleware()
+        finally:
+            settings.AGENTMESH_REPLAY_CACHE_ALIAS = "default"
+
     def test_missing_audience_fails_at_startup(self):
         audience = settings.AGENTMESH_AUDIENCE
         settings.AGENTMESH_AUDIENCE = ""
@@ -478,6 +647,14 @@ class TestAgentTrustMiddleware:
                 _make_middleware()
         finally:
             del settings.AGENTMESH_REPLAY_WINDOW_SECONDS
+
+    def test_invalid_max_signed_body_size_fails_at_startup(self):
+        settings.AGENTMESH_MAX_SIGNED_BODY_BYTES = 0
+        try:
+            with pytest.raises(ImproperlyConfigured, match="MAX_SIGNED_BODY_BYTES"):
+                _make_middleware()
+        finally:
+            del settings.AGENTMESH_MAX_SIGNED_BODY_BYTES
 
 
 class TestTrustRequiredDecorator:

--- a/agent-governance-python/agent-mesh/tests/test_django_middleware.py
+++ b/agent-governance-python/agent-mesh/tests/test_django_middleware.py
@@ -361,7 +361,9 @@ class TestAgentTrustMiddleware:
         finally:
             del settings.AGENTMESH_AGENT_KEYS
 
-    @pytest.mark.parametrize("nonce", ["not base64!", "c2hvcnQ", "a" * 129])
+    @pytest.mark.parametrize(
+        "nonce", ["not base64!", base64.b64encode(b"short").decode(), "a" * 129]
+    )
     def test_malformed_or_undersized_nonce_is_rejected(self, nonce):
         from cryptography.hazmat.primitives.asymmetric import ed25519
 

--- a/agent-governance-python/agent-mesh/tests/test_django_middleware.py
+++ b/agent-governance-python/agent-mesh/tests/test_django_middleware.py
@@ -6,9 +6,12 @@
 
 from __future__ import annotations
 
+import base64
 import importlib
 import json
+import secrets
 import sys
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 
@@ -25,18 +28,30 @@ if not settings.configured:
         ROOT_URLCONF="tests.test_django_middleware",  # self-referencing
         MIDDLEWARE=[],
         SECRET_KEY="test-secret-key",
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                "LOCATION": "agentmesh-django-tests",
+            }
+        },
+        AGENTMESH_AUDIENCE="test-service",
+        AGENTMESH_REPLAY_CACHE_ALIAS="default",
+        AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE=True,
     )
 
 import django as _django  # noqa: E402
 
 _django.setup()
 
+from django.core.cache import caches  # noqa: E402
+from django.core.exceptions import ImproperlyConfigured  # noqa: E402
 from django.http import HttpResponse, JsonResponse  # noqa: E402
 from django.test import RequestFactory  # noqa: E402
 from django.urls import path  # noqa: E402
 
 from agentmesh.integrations.django_middleware import (  # noqa: E402
     AgentTrustMiddleware,
+    build_request_signature_payload,
     trust_exempt,
     trust_required,
 )
@@ -88,6 +103,53 @@ def _get(path: str, *, did: str = "", sig: str = "", factory=None):
     return factory.get(path, **headers)
 
 
+def _signed_request(
+    private_key,
+    agent_did: str,
+    path: str = "/api/data/",
+    *,
+    method: str = "GET",
+    body: bytes = b"",
+    content_type: str = "application/octet-stream",
+    timestamp: str | None = None,
+    nonce: str | None = None,
+    audience: str = "test-service",
+    factory=None,
+):
+    """Build a request carrying a valid, request-bound AgentMesh signature."""
+    factory = factory or RequestFactory()
+    timestamp = timestamp or datetime.now(UTC).isoformat()
+    nonce = nonce or secrets.token_urlsafe(16)
+    request = factory.generic(method, path, data=body, content_type=content_type)
+    query_string = request.META.get("QUERY_STRING", "")
+    request_target = request.path + (f"?{query_string}" if query_string else "")
+    payload = build_request_signature_payload(
+        agent_did=agent_did,
+        audience=audience,
+        timestamp=timestamp,
+        nonce=nonce,
+        method=method,
+        request_target=request_target,
+        body=body,
+        content_type=request.META.get("CONTENT_TYPE", ""),
+    )
+    signature = base64.b64encode(private_key.sign(payload)).decode()
+    request.META.update(
+        HTTP_X_AGENT_DID=agent_did,
+        HTTP_X_AGENT_SIGNATURE=signature,
+        HTTP_X_AGENT_TIMESTAMP=timestamp,
+        HTTP_X_AGENT_NONCE=nonce,
+    )
+    return request
+
+
+@pytest.fixture(autouse=True)
+def _clear_replay_cache():
+    caches["default"].clear()
+    yield
+    caches["default"].clear()
+
+
 # ── Test class ───────────────────────────────────────────────────────
 
 
@@ -104,18 +166,15 @@ class TestAgentTrustMiddleware:
 
     def test_valid_did_with_signature_passes(self):
         from cryptography.hazmat.primitives.asymmetric import ed25519
-        import base64
 
-        # Create agent keypair and sign the DID
         private_key = ed25519.Ed25519PrivateKey.generate()
         public_key = private_key.public_key()
         agent_did = "did:mesh:abc123"
-        sig = base64.b64encode(private_key.sign(agent_did.encode("utf-8"))).decode()
 
         settings.AGENTMESH_AGENT_KEYS = {agent_did: public_key}
         try:
             mw = _make_middleware()
-            request = _get("/api/data/", did=agent_did, sig=sig)
+            request = _signed_request(private_key, agent_did)
             response = mw(request)
             assert response.status_code == 200
             assert request.agent_did == agent_did  # type: ignore[attr-defined]
@@ -146,7 +205,8 @@ class TestAgentTrustMiddleware:
         settings.AGENTMESH_AGENT_KEYS = {agent_did: public_key}
         try:
             mw = _make_middleware()
-            request = _get("/api/data/", did=agent_did, sig="totally-not-a-valid-sig")
+            request = _signed_request(private_key, agent_did)
+            request.META["HTTP_X_AGENT_SIGNATURE"] = "totally-not-a-valid-sig"
             response = mw(request)
             assert response.status_code == 403
             body = json.loads(response.content)
@@ -180,18 +240,16 @@ class TestAgentTrustMiddleware:
     def test_settings_override_defaults(self):
         """Custom settings override the built-in defaults."""
         from cryptography.hazmat.primitives.asymmetric import ed25519
-        import base64
 
         private_key = ed25519.Ed25519PrivateKey.generate()
         public_key = private_key.public_key()
         agent_did = "did:mesh:low_ok"
-        sig = base64.b64encode(private_key.sign(agent_did.encode("utf-8"))).decode()
 
         settings.AGENTMESH_MIN_TRUST_SCORE = 300
         settings.AGENTMESH_AGENT_KEYS = {agent_did: public_key}
         try:
             mw = _make_middleware()
-            request = _get("/api/data/", did=agent_did, sig=sig)
+            request = _signed_request(private_key, agent_did)
             response = mw(request)
             # score 750 >= new threshold 300 → should pass
             assert response.status_code == 200
@@ -202,29 +260,194 @@ class TestAgentTrustMiddleware:
     def test_custom_did_header(self):
         """AGENTMESH_DID_HEADER changes which header is read."""
         from cryptography.hazmat.primitives.asymmetric import ed25519
-        import base64
 
         private_key = ed25519.Ed25519PrivateKey.generate()
         public_key = private_key.public_key()
         agent_did = "did:mesh:custom"
-        sig = base64.b64encode(private_key.sign(agent_did.encode("utf-8"))).decode()
 
         settings.AGENTMESH_DID_HEADER = "X-Custom-DID"
         settings.AGENTMESH_AGENT_KEYS = {agent_did: public_key}
         try:
             mw = _make_middleware()
-            factory = RequestFactory()
-            request = factory.get(
-                "/api/data/",
-                HTTP_X_CUSTOM_DID=agent_did,
-                HTTP_X_AGENT_SIGNATURE=sig,
-            )
+            request = _signed_request(private_key, agent_did)
+            request.META["HTTP_X_CUSTOM_DID"] = request.META.pop("HTTP_X_AGENT_DID")
             response = mw(request)
             assert response.status_code == 200
             assert request.agent_did == agent_did  # type: ignore[attr-defined]
         finally:
             del settings.AGENTMESH_DID_HEADER
             del settings.AGENTMESH_AGENT_KEYS
+
+    def test_replayed_request_is_rejected(self):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:replay"
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            mw = _make_middleware()
+            original = _signed_request(private_key, agent_did)
+            replay = RequestFactory().get(
+                "/api/data/",
+                **{
+                    key: value
+                    for key, value in original.META.items()
+                    if key.startswith("HTTP_X_AGENT_")
+                },
+            )
+
+            assert mw(original).status_code == 200
+            assert mw(replay).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    @pytest.mark.parametrize("offset", [timedelta(minutes=-6), timedelta(minutes=6)])
+    def test_timestamp_outside_replay_window_is_rejected(self, offset):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:stale"
+        timestamp = (datetime.now(UTC) + offset).isoformat()
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            request = _signed_request(private_key, agent_did, timestamp=timestamp)
+            assert _make_middleware()(request).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    def test_legacy_bare_did_signature_is_rejected(self):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:legacy"
+        request = _signed_request(private_key, agent_did)
+        request.META["HTTP_X_AGENT_SIGNATURE"] = base64.b64encode(
+            private_key.sign(agent_did.encode("utf-8"))
+        ).decode()
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            assert _make_middleware()(request).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    @pytest.mark.parametrize(
+        ("changed_method", "changed_path", "changed_body"),
+        [
+            ("POST", "/api/data/", b""),
+            ("GET", "/api/high/", b""),
+            ("POST", "/api/data/", b"changed"),
+        ],
+    )
+    def test_signature_is_bound_to_request(self, changed_method, changed_path, changed_body):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:bound"
+        signed = _signed_request(private_key, agent_did)
+        tampered = RequestFactory().generic(
+            changed_method,
+            changed_path,
+            data=changed_body,
+            content_type="application/octet-stream",
+            **{
+                key: value
+                for key, value in signed.META.items()
+                if key.startswith("HTTP_X_AGENT_")
+            },
+        )
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            assert _make_middleware()(tampered).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    @pytest.mark.parametrize("nonce", ["not base64!", "c2hvcnQ", "a" * 129])
+    def test_malformed_or_undersized_nonce_is_rejected(self, nonce):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:bad-nonce"
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            request = _signed_request(private_key, agent_did, nonce=nonce)
+            assert _make_middleware()(request).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    def test_signature_is_bound_to_query_string(self):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:query-bound"
+        signed = _signed_request(private_key, agent_did, path="/api/data/?scope=read")
+        tampered = RequestFactory().get(
+            "/api/data/?scope=write",
+            **{
+                key: value
+                for key, value in signed.META.items()
+                if key.startswith("HTTP_X_AGENT_")
+            },
+        )
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            assert _make_middleware()(tampered).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    def test_signature_is_bound_to_audience(self):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:audience-bound"
+        request = _signed_request(private_key, agent_did, audience="another-service")
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            assert _make_middleware()(request).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    def test_replay_cache_failure_is_fail_closed(self, monkeypatch):
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        agent_did = "did:mesh:cache-failure"
+        settings.AGENTMESH_AGENT_KEYS = {agent_did: private_key.public_key()}
+        try:
+            mw = _make_middleware()
+
+            def _cache_failure(*args, **kwargs):
+                raise RuntimeError("cache unavailable")
+
+            monkeypatch.setattr(mw._replay_cache, "add", _cache_failure)
+            request = _signed_request(private_key, agent_did)
+            assert mw(request).status_code == 403
+        finally:
+            del settings.AGENTMESH_AGENT_KEYS
+
+    def test_local_replay_cache_requires_explicit_development_opt_in(self):
+        settings.AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE = False
+        try:
+            with pytest.raises(ImproperlyConfigured, match="cannot prevent replay"):
+                _make_middleware()
+        finally:
+            settings.AGENTMESH_ALLOW_LOCAL_REPLAY_CACHE = True
+
+    def test_missing_audience_fails_at_startup(self):
+        audience = settings.AGENTMESH_AUDIENCE
+        settings.AGENTMESH_AUDIENCE = ""
+        try:
+            with pytest.raises(ImproperlyConfigured, match="AGENTMESH_AUDIENCE"):
+                _make_middleware()
+        finally:
+            settings.AGENTMESH_AUDIENCE = audience
+
+    def test_invalid_replay_window_fails_at_startup(self):
+        settings.AGENTMESH_REPLAY_WINDOW_SECONDS = 0
+        try:
+            with pytest.raises(ImproperlyConfigured, match="REPLAY_WINDOW_SECONDS"):
+                _make_middleware()
+        finally:
+            del settings.AGENTMESH_REPLAY_WINDOW_SECONDS
 
 
 class TestTrustRequiredDecorator:
@@ -233,17 +456,15 @@ class TestTrustRequiredDecorator:
     def test_per_view_threshold_enforced(self):
         """@trust_required(min_score=800) rejects score 750 even with valid sig."""
         from cryptography.hazmat.primitives.asymmetric import ed25519
-        import base64
 
         private_key = ed25519.Ed25519PrivateKey.generate()
         public_key = private_key.public_key()
         agent_did = "did:mesh:abc"
-        sig = base64.b64encode(private_key.sign(agent_did.encode("utf-8"))).decode()
 
         settings.AGENTMESH_AGENT_KEYS = {agent_did: public_key}
         try:
             mw = _make_middleware(get_response=_high_trust_view)
-            request = _get("/api/high/", did=agent_did, sig=sig)
+            request = _signed_request(private_key, agent_did, path="/api/high/")
             response = mw(request)
             # score 750 < per-view 800 → 403
             assert response.status_code == 403


### PR DESCRIPTION
## Related Issue
Fixes #3781

## Problem & Solution

**Problem:** `AgentTrustMiddleware` verified Ed25519 signatures over only the agent DID. Because the signed value was static, a captured `(X-Agent-DID, X-Agent-Signature)` pair could be replayed indefinitely and reused across protected endpoints.

**Solution:** This PR replaces bare-DID signatures with a versioned, canonical request envelope binding the signature to:

- Agent DID
- Service audience
- ISO-8601 timestamp
- Cryptographically random nonce
- HTTP method
- Request path and query string
- Content type
- SHA-256 request-body digest

The middleware validates timestamp freshness and uses an atomic, shared Django cache to reject reused nonces. It fails closed when the replay cache is unavailable and rejects unsafe local-memory cache configuration unless explicitly enabled for development.

Legacy signatures over only the DID are intentionally rejected. The PR also exports a canonical payload helper so clients do not need to reproduce security-sensitive serialization logic.

## Impact on Your Work

This closes a capture-replay authentication vulnerability in the Django AgentMesh integration. A captured static signature can no longer serve as an indefinite bearer credential or be reused unchanged against another method, path, query, body, content type, or service audience.

Deployments must configure a service-specific `AGENTMESH_AUDIENCE` and a shared replay cache with atomic `add()` semantics. Clients must send the new timestamp and nonce headers and sign the canonical request envelope.

## Timeline

As soon as practical due to the security impact and associated MSRC report.

## Alternatives Considered

A minimal change signing `DID|timestamp` was considered. It would limit replay duration but would still permit replay during the timestamp window and would not prevent cross-endpoint, cross-method, or body-substitution attacks.

A timestamp-only approach was rejected in favor of a one-time nonce, shared replay state, service audience, and complete request binding.

An in-process nonce cache was also considered but rejected for production use because it cannot prevent replay across Django workers or application replicas.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected

**Core & runtime:**
- [x] agent-governance-toolkit-core
- [ ] agent-primitives
- [ ] agent-os
- [x] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-compliance

**Governance & security:**
- [ ] agent-mcp-governance
- [ ] agent-rag-governance
- [ ] agent-sandbox
- [ ] agent-discovery
- [ ] agt-policies
- [ ] policy-engine

**Platform & tooling:**
- [ ] agent-hypervisor
- [ ] agent-lightning
- [ ] agent-marketplace
- [ ] agent-governance-toolkit-cli
- [ ] agent-governance-toolkit-integrations
- [ ] agent-governance-toolkit-protocols
- [ ] agentmesh-integrations (framework integrations)

**CLI plugins:**
- [ ] agent-governance CLI plugins (copilot-cli / claude-code / opencode / antigravity-cli)

**Shared / other:**
- [ ] schemas
- [ ] action (GitHub Action)
- [ ] examples
- [ ] docs / root

## Testing

The focused Django middleware test suite passes with 30 tests. Changed Python files also pass Ruff, editor diagnostics, and whitespace validation.

### Unit Testing

Updated and added tests covering:

- Valid request-bound Ed25519 signatures
- Immediate nonce replay rejection
- Stale and excessively future-dated timestamps
- Missing, malformed, undersized, and oversized nonces
- Rejection of legacy bare-DID signatures
- Method, path, query-string, body, and audience binding
- Replay-cache failure with fail-closed behavior
- Rejection of unsafe local-memory caches without development opt-in
- Missing audience and invalid replay-window startup configuration
- Existing per-view trust thresholds and exemption behavior

### Manual Testing

Commands run:

```bash
python -m pytest agent-governance-python/agent-mesh/tests/test_django_middleware.py -q
python -m ruff check agent-governance-python/agent-mesh/tests/test_django_middleware.py
git diff --check