### PR TITLE
feat(opencode): add command and URL allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ACS artifact validation API** - added one bounded Rust-core validator for canonical manifest schema checks, typed ACS semantics, and OPA Rego parsing, exposed with the same structured result through Rust, Python, Node, and .NET. The `acs-generator` CLI now consumes this shared SDK surface.
 
 ### Changed
+- **OpenCode URL policy hardening** — HTTP(S) forms such as `https:host` are canonicalized before existing `urlRules` are evaluated, and HTTP(S) URL authorities containing backslashes are denied regardless of `urlDefaultEffect` to avoid parser ambiguity.
 - **BREAKING: `acs-generator` is CLI-only in `0.4.0b0`.** Removed top-level library re-exports such as `GenerationEngine` and `FakeLanguageModel`. Reusable manifest and Rego validation now lives under `agent_control_specification.validation`; the Python SDK moves to `0.3.1b1`.
 - **BREAKING: Python policy runtime now uses native ACS only.** Removed the
   compatibility bridge, pre-ACS rule and result types, runtime folder

--- a/agent-governance-opencode/README.md
+++ b/agent-governance-opencode/README.md
@@ -127,6 +127,45 @@ The plugin loads policy from (in order):
 Audit log path defaults to `~/.config/opencode/agt/audit.json` and can be
 overridden via `AGT_OPENCODE_AUDIT_PATH`.
 
+### Positive command and URL allowlists
+
+Positive allowlists are opt-in, so existing policies keep their current
+behavior. Set the relevant default effect to `deny` to make unmatched values
+fail closed.
+
+For command-bearing tool calls, configure `toolPolicies` with:
+
+- `allowedCommandPatterns`: regex pattern objects with `source` and optional
+  `flags`
+- `commandDefaultEffect`: `allow` (default) or `deny`
+
+Commands are normalized only for outer whitespace and CRLF line endings before
+matching. Use anchored patterns when the whole command must match. Stateful
+regex flags (`g` and `y`) are rejected because they make repeated evaluations
+history-dependent.
+
+For HTTP(S) resources, configure `directResourcePolicies` with:
+
+- `allowedDomains`: exact hosts or `*.example.com` subdomain wildcards, with an
+  optional explicit port such as `internal.example:8443`
+- `allowedUrlPatterns`: regex pattern objects evaluated against the normalized
+  full URL
+- `urlDefaultEffect`: `allow` (default) or `deny`
+
+A wildcard such as `*.example.com` does not include the apex `example.com`.
+A domain without a port matches that host on any port; specifying a port
+restricts the match to that effective port. Every HTTP(S) string found in tool
+arguments is checked, so an allowed primary URL does not make a separate,
+unapproved redirect-target argument acceptable. Runtime redirects that are not
+surfaced to the plugin remain the responsibility of the HTTP client or host.
+
+Existing deny and review rules keep their precedence. An allowlist match only
+means the positive gate is satisfied; it cannot override a deny from
+`blockedToolCalls`, `urlRules`, or another policy backend.
+
+A complete opt-in example is provided at
+`config/allowlist-policy.example.json`.
+
 ## Important parity notes
 
 - OpenCode's in-process plugin contract does not currently expose a server-side

--- a/agent-governance-opencode/README.md
+++ b/agent-governance-opencode/README.md
@@ -129,9 +129,8 @@ overridden via `AGT_OPENCODE_AUDIT_PATH`.
 
 ### Positive command and URL allowlists
 
-Positive allowlists are opt-in, so existing policies keep their current
-behavior. Set the relevant default effect to `deny` to make unmatched values
-fail closed.
+Positive allowlist gates are opt-in. Set the relevant default effect to `deny`
+to make unmatched values fail closed.
 
 For command-bearing tool calls, configure `toolPolicies` with:
 
@@ -140,9 +139,11 @@ For command-bearing tool calls, configure `toolPolicies` with:
 - `commandDefaultEffect`: `allow` (default) or `deny`
 
 Commands are normalized only for outer whitespace and CRLF line endings before
-matching. Use anchored patterns when the whole command must match. Stateful
-regex flags (`g` and `y`) are rejected because they make repeated evaluations
-history-dependent.
+matching. When the whole command must be approved, use fully anchored patterns
+and avoid broad suffixes such as `(?:\\s|$)` that also accept shell chaining,
+command substitution, or additional arguments. The shipped example uses exact,
+fully anchored command forms. Regex flags `g`, `y`, `m`, and `s` are rejected so
+stateful or multiline matching cannot weaken an anchored command policy.
 
 For HTTP(S) resources, configure `directResourcePolicies` with:
 
@@ -153,11 +154,26 @@ For HTTP(S) resources, configure `directResourcePolicies` with:
 - `urlDefaultEffect`: `allow` (default) or `deny`
 
 A wildcard such as `*.example.com` does not include the apex `example.com`.
-A domain without a port matches that host on any port; specifying a port
-restricts the match to that effective port. Every HTTP(S) string found in tool
-arguments is checked, so an allowed primary URL does not make a separate,
-unapproved redirect-target argument acceptable. Runtime redirects that are not
-surfaced to the plugin remain the responsibility of the HTTP client or host.
+A domain without a port matches that host on any port and on both `http://` and
+`https://`; specifying a port restricts the match to that effective port. If a
+policy must allow only HTTPS for a destination, use an anchored
+`allowedUrlPatterns` entry for `https://...` rather than an `allowedDomains`
+entry for that host.
+
+`urlDefaultEffect: "deny"` governs HTTP(S) strings that are surfaced as tool
+arguments. It is not a process-wide or network-layer default deny. URLs embedded
+inside shell command strings, scheme-relative values such as `//evil.example`,
+`ftp:` URLs, schemeless hosts, and redirects hidden inside an HTTP client are
+outside this URL hook boundary. Pair URL restrictions with
+`commandDefaultEffect: "deny"` and a narrow command allowlist when command tools
+can initiate network access.
+
+Every surfaced HTTP(S) string is checked, so an allowed primary URL does not
+make a separate, unapproved redirect-target argument acceptable. HTTP(S) values
+are canonicalized before existing `urlRules` are evaluated, including slashless
+special-scheme forms such as `https:example.com`. Raw HTTP(S) authorities that
+contain a backslash are denied because downstream clients can disagree about
+which host such a value targets.
 
 Existing deny and review rules keep their precedence. An allowlist match only
 means the positive gate is satisfied; it cannot override a deny from

--- a/agent-governance-opencode/README.md
+++ b/agent-governance-opencode/README.md
@@ -163,17 +163,17 @@ entry for that host.
 `urlDefaultEffect: "deny"` governs HTTP(S) strings that are surfaced as tool
 arguments. It is not a process-wide or network-layer default deny. URLs embedded
 inside shell command strings, scheme-relative values such as `//evil.example`,
-`ftp:` URLs, schemeless hosts, and redirects hidden inside an HTTP client are
-outside this URL hook boundary. Pair URL restrictions with
+`ftp:` URLs, host names without a scheme, and redirects hidden inside an HTTP
+client are outside this URL hook boundary. Pair URL restrictions with
 `commandDefaultEffect: "deny"` and a narrow command allowlist when command tools
 can initiate network access.
 
 Every surfaced HTTP(S) string is checked, so an allowed primary URL does not
 make a separate, unapproved redirect-target argument acceptable. HTTP(S) values
-are canonicalized before existing `urlRules` are evaluated, including slashless
-special-scheme forms such as `https:example.com`. Raw HTTP(S) authorities that
-contain a backslash are denied because downstream clients can disagree about
-which host such a value targets.
+are canonicalized before existing `urlRules` are evaluated, including special
+scheme forms without `//` such as `https:example.com`. Raw HTTP(S) authorities
+that contain a backslash are denied because downstream clients can disagree
+about which host such a value targets.
 
 Existing deny and review rules keep their precedence. An allowlist match only
 means the positive gate is satisfied; it cannot override a deny from

--- a/agent-governance-opencode/config/allowlist-policy.example.json
+++ b/agent-governance-opencode/config/allowlist-policy.example.json
@@ -15,11 +15,11 @@
     "commandDefaultEffect": "deny",
     "allowedCommandPatterns": [
       {
-        "source": "^git\\s+(?:status|diff)(?:\\s|$)",
+        "source": "^git[ \\t]+(?:status|diff)$",
         "flags": "i"
       },
       {
-        "source": "^npm\\s+(?:test|run\\s+(?:test|lint|check))(?:\\s|$)",
+        "source": "^npm[ \\t]+(?:test|run[ \\t]+(?:test|lint|check))$",
         "flags": "i"
       }
     ]

--- a/agent-governance-opencode/config/allowlist-policy.example.json
+++ b/agent-governance-opencode/config/allowlist-policy.example.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "version": 1,
+  "mode": "enforce",
+  "denyOnPolicyError": true,
+  "minimumPromptDefenseGrade": "B",
+  "toolPolicies": {
+    "allowedTools": [
+      "bash",
+      "webfetch"
+    ],
+    "blockedTools": [],
+    "reviewTools": [],
+    "defaultEffect": "allow",
+    "commandDefaultEffect": "deny",
+    "allowedCommandPatterns": [
+      {
+        "source": "^git\\s+(?:status|diff)(?:\\s|$)",
+        "flags": "i"
+      },
+      {
+        "source": "^npm\\s+(?:test|run\\s+(?:test|lint|check))(?:\\s|$)",
+        "flags": "i"
+      }
+    ]
+  },
+  "blockedToolCalls": [],
+  "directResourcePolicies": {
+    "pathRules": [],
+    "urlRules": [],
+    "urlDefaultEffect": "deny",
+    "allowedDomains": [
+      "api.github.com",
+      "*.example.com",
+      "internal.example.net:8443"
+    ],
+    "allowedUrlPatterns": [
+      {
+        "source": "^https://status\\.example\\.net/health(?:\\?|$)",
+        "flags": "i"
+      }
+    ]
+  },
+  "additionalContext": [],
+  "poisoningPatterns": []
+}

--- a/agent-governance-opencode/lib/opencode-policy.mjs
+++ b/agent-governance-opencode/lib/opencode-policy.mjs
@@ -322,15 +322,15 @@ function normalizeCommandText(value) {
 }
 
 function evaluateUrlAllowlist(urlPolicy, basePolicy, context) {
-  if (urlPolicy.defaultEffect !== "deny") {
-    return null;
-  }
-
+  const enforcePositiveAllowlist = urlPolicy.defaultEffect === "deny";
   const candidates = collectHttpUrlCandidates(context.rawToolArgs);
   let reviewDecision;
 
   for (const candidate of candidates) {
     if (!candidate.valid) {
+      if (!enforcePositiveAllowlist) {
+        continue;
+      }
       return {
         backend: "agt-positive-allowlists",
         decision: "deny",
@@ -358,7 +358,7 @@ function evaluateUrlAllowlist(urlPolicy, basePolicy, context) {
       };
     }
 
-    if (isAllowedUrlCandidate(candidate, urlPolicy)) {
+    if (!enforcePositiveAllowlist || isAllowedUrlCandidate(candidate, urlPolicy)) {
       continue;
     }
 

--- a/agent-governance-opencode/lib/opencode-policy.mjs
+++ b/agent-governance-opencode/lib/opencode-policy.mjs
@@ -4,12 +4,16 @@
 import { isIP } from "node:net";
 
 import {
+  evaluateDirectResourceAccess,
   loadPolicy as loadBasePolicy,
 } from "./policy.mjs";
 
 export * from "./policy.mjs";
 
 const DEFAULT_ALLOWLIST_EFFECT = "allow";
+const COMMAND_ARGUMENT_KEYS = ["command", "bash", "powershell", "script", "cmd"];
+const COMMAND_TOOL_NAME_PATTERN =
+  /(?:^|[._:/-])(?:bash|shell|sh|zsh|fish|powershell|pwsh|cmd|terminal|exec|execute|command)(?:$|[._:/-])/i;
 
 /**
  * Load the existing OpenCode policy and attach positive command/URL allowlists.
@@ -25,7 +29,9 @@ export async function loadPolicy(options = {}) {
   try {
     const positiveAllowlists = compilePositiveAllowlistPolicy(state.policy.raw);
     state.policy.positiveAllowlists = positiveAllowlists;
-    state.policyEngine.registerBackend(createPositiveAllowlistBackend(positiveAllowlists));
+    state.policyEngine.registerBackend(
+      createPositiveAllowlistBackend(positiveAllowlists, state.policy),
+    );
   } catch (error) {
     const policyError = error instanceof Error ? error : new Error(String(error));
     state.policy.positiveAllowlists = emptyPositiveAllowlistPolicy();
@@ -156,7 +162,7 @@ function compileAllowedDomain(entry, index) {
   }
 
   const source = entry.trim().toLowerCase();
-  if (source.includes("://") || /[\s/@?#]/.test(source)) {
+  if (source.includes("://") || /[\s/@?#\\]/.test(source)) {
     throw new Error(
       `directResourcePolicies.allowedDomains[${index}] must contain only a host and optional port.`,
     );
@@ -248,7 +254,7 @@ function stripIpv6Brackets(hostname) {
   return hostname.replace(/^\[/, "").replace(/\]$/, "");
 }
 
-function createPositiveAllowlistBackend(policy) {
+function createPositiveAllowlistBackend(positivePolicy, basePolicy) {
   return {
     name: "agt-positive-allowlists",
     evaluateAction(action, context) {
@@ -256,12 +262,12 @@ function createPositiveAllowlistBackend(policy) {
         return "allow";
       }
 
-      const commandDecision = evaluateCommandAllowlist(policy.commands, context);
+      const commandDecision = evaluateCommandAllowlist(positivePolicy.commands, context);
       if (commandDecision) {
         return commandDecision;
       }
 
-      const urlDecision = evaluateUrlAllowlist(policy.urls, context);
+      const urlDecision = evaluateUrlAllowlist(positivePolicy.urls, basePolicy, context);
       if (urlDecision) {
         return urlDecision;
       }
@@ -276,7 +282,7 @@ function evaluateCommandAllowlist(commandPolicy, context) {
     return null;
   }
 
-  const command = normalizeCommandText(context.commandText);
+  const command = extractAllowlistedCommand(context);
   if (!command) {
     return null;
   }
@@ -293,22 +299,62 @@ function evaluateCommandAllowlist(commandPolicy, context) {
   };
 }
 
+function extractAllowlistedCommand(context) {
+  const args = context.rawToolArgs;
+  if (args && typeof args === "object" && !Array.isArray(args)) {
+    for (const key of COMMAND_ARGUMENT_KEYS) {
+      const value = args[key];
+      if (typeof value === "string" && value.trim()) {
+        return normalizeCommandText(value);
+      }
+    }
+  }
+
+  const toolName = String(context.toolName ?? "").trim();
+  if (!COMMAND_TOOL_NAME_PATTERN.test(toolName)) {
+    return "";
+  }
+  return normalizeCommandText(context.commandText);
+}
+
 function normalizeCommandText(value) {
   return String(value ?? "").replace(/\r\n?/g, "\n").trim();
 }
 
-function evaluateUrlAllowlist(urlPolicy, context) {
+function evaluateUrlAllowlist(urlPolicy, basePolicy, context) {
   if (urlPolicy.defaultEffect !== "deny") {
     return null;
   }
 
   const candidates = collectHttpUrlCandidates(context.rawToolArgs);
+  let reviewDecision;
+
   for (const candidate of candidates) {
     if (!candidate.valid) {
       return {
         backend: "agt-positive-allowlists",
         decision: "deny",
         reason: "URL allowlist denied a malformed HTTP(S) URL in tool arguments.",
+      };
+    }
+
+    const existingDecision = evaluateDirectResourceAccess(basePolicy, {
+      cwd: context.cwd,
+      rawToolArgs: { url: candidate.normalizedUrl },
+      toolName: context.toolName,
+    });
+    if (existingDecision?.effect === "deny") {
+      return {
+        backend: "agt-positive-allowlists",
+        decision: "deny",
+        reason: existingDecision.reason,
+      };
+    }
+    if (existingDecision?.effect === "review") {
+      reviewDecision ??= {
+        backend: "agt-positive-allowlists",
+        decision: "review",
+        reason: existingDecision.reason,
       };
     }
 
@@ -323,7 +369,7 @@ function evaluateUrlAllowlist(urlPolicy, context) {
     };
   }
 
-  return null;
+  return reviewDecision ?? null;
 }
 
 function collectHttpUrlCandidates(value) {
@@ -336,7 +382,7 @@ function collectHttpUrlCandidates(value) {
     const current = stack.pop();
     if (typeof current === "string") {
       const raw = current.trim();
-      if (!/^https?:\/\//i.test(raw)) {
+      if (!/^https?:/i.test(raw)) {
         continue;
       }
 

--- a/agent-governance-opencode/lib/opencode-policy.mjs
+++ b/agent-governance-opencode/lib/opencode-policy.mjs
@@ -118,10 +118,11 @@ function compileRegexPatterns(value, label) {
     if (typeof flags !== "string") {
       throw new Error(`${label}[${index}].flags must be a string.`);
     }
-    // Global/sticky regexes mutate lastIndex across calls and would make a
-    // policy decision depend on evaluation history.
-    if (/[gy]/.test(flags)) {
-      throw new Error(`${label}[${index}] must not use stateful g/y regex flags.`);
+    // Stateful and line/dot mode regexes can make security-sensitive matching
+    // history-dependent or allow an anchored pattern to match only one line of
+    // a multi-command string.
+    if (/[gyms]/.test(flags)) {
+      throw new Error(`${label}[${index}] must not use g/y/m/s regex flags.`);
     }
 
     let regex;
@@ -282,39 +283,66 @@ function evaluateCommandAllowlist(commandPolicy, context) {
     return null;
   }
 
-  const command = extractAllowlistedCommand(context);
-  if (!command) {
-    return null;
-  }
-
-  if (commandPolicy.patterns.some((pattern) => pattern.regex.test(command))) {
-    return null;
-  }
-
   const toolName = String(context.toolName ?? "unknown");
-  return {
-    backend: "agt-positive-allowlists",
-    decision: "deny",
-    reason: `Command allowlist denied an unapproved command for tool '${toolName}'.`,
-  };
+  const commandResult = collectAllowlistedCommands(context);
+  if (commandResult.invalid) {
+    return {
+      backend: "agt-positive-allowlists",
+      decision: "deny",
+      reason: `Command allowlist denied malformed command arguments for tool '${toolName}'.`,
+    };
+  }
+  if (commandResult.commands.length === 0) {
+    return null;
+  }
+
+  for (const command of commandResult.commands) {
+    if (commandPolicy.patterns.some((pattern) => pattern.regex.test(command))) {
+      continue;
+    }
+    return {
+      backend: "agt-positive-allowlists",
+      decision: "deny",
+      reason: `Command allowlist denied an unapproved command for tool '${toolName}'.`,
+    };
+  }
+
+  return null;
 }
 
-function extractAllowlistedCommand(context) {
+function collectAllowlistedCommands(context) {
   const args = context.rawToolArgs;
+  const commands = [];
+  let sawCommandKey = false;
+
   if (args && typeof args === "object" && !Array.isArray(args)) {
     for (const key of COMMAND_ARGUMENT_KEYS) {
-      const value = args[key];
-      if (typeof value === "string" && value.trim()) {
-        return normalizeCommandText(value);
+      if (!Object.prototype.hasOwnProperty.call(args, key)) {
+        continue;
       }
+      sawCommandKey = true;
+      const value = args[key];
+      if (typeof value !== "string" || !value.trim()) {
+        return { commands: [], invalid: true };
+      }
+      commands.push(normalizeCommandText(value));
     }
+  }
+
+  if (sawCommandKey) {
+    return { commands, invalid: false };
   }
 
   const toolName = String(context.toolName ?? "").trim();
   if (!COMMAND_TOOL_NAME_PATTERN.test(toolName)) {
-    return "";
+    return { commands: [], invalid: false };
   }
-  return normalizeCommandText(context.commandText);
+
+  const fallbackCommand = normalizeCommandText(context.commandText);
+  return {
+    commands: fallbackCommand ? [fallbackCommand] : [],
+    invalid: false,
+  };
 }
 
 function normalizeCommandText(value) {
@@ -328,13 +356,16 @@ function evaluateUrlAllowlist(urlPolicy, basePolicy, context) {
 
   for (const candidate of candidates) {
     if (!candidate.valid) {
-      if (!enforcePositiveAllowlist) {
+      const denyAmbiguousAuthority = candidate.invalidReason === "ambiguous-authority-backslash";
+      if (!enforcePositiveAllowlist && !denyAmbiguousAuthority) {
         continue;
       }
       return {
         backend: "agt-positive-allowlists",
         decision: "deny",
-        reason: "URL allowlist denied a malformed HTTP(S) URL in tool arguments.",
+        reason: denyAmbiguousAuthority
+          ? "URL governance denied an ambiguous HTTP(S) authority containing a backslash."
+          : "URL allowlist denied a malformed HTTP(S) URL in tool arguments.",
       };
     }
 
@@ -387,19 +418,27 @@ function collectHttpUrlCandidates(value) {
       }
 
       let candidate;
-      try {
-        const url = new URL(raw);
-        if (url.protocol !== "http:" && url.protocol !== "https:") {
-          continue;
-        }
+      if (hasAmbiguousHttpAuthorityBackslash(raw)) {
         candidate = {
-          normalizedUrl: url.toString(),
-          origin: url.origin,
-          url,
-          valid: true,
+          invalidReason: "ambiguous-authority-backslash",
+          raw,
+          valid: false,
         };
-      } catch {
-        candidate = { valid: false };
+      } else {
+        try {
+          const url = new URL(raw);
+          if (url.protocol !== "http:" && url.protocol !== "https:") {
+            continue;
+          }
+          candidate = {
+            normalizedUrl: url.toString(),
+            origin: url.origin,
+            url,
+            valid: true,
+          };
+        } catch {
+          candidate = { raw, valid: false };
+        }
       }
 
       const key = candidate.valid ? candidate.normalizedUrl : `invalid:${raw}`;
@@ -426,6 +465,23 @@ function collectHttpUrlCandidates(value) {
   }
 
   return candidates;
+}
+
+function hasAmbiguousHttpAuthorityBackslash(raw) {
+  const scheme = /^https?:/i.exec(raw)?.[0];
+  if (!scheme) {
+    return false;
+  }
+
+  let remainder = raw.slice(scheme.length);
+  if (remainder.startsWith("//")) {
+    remainder = remainder.slice(2);
+  }
+
+  const boundaryIndexes = [remainder.indexOf("/"), remainder.indexOf("?"), remainder.indexOf("#")]
+    .filter((index) => index >= 0);
+  const authorityEnd = boundaryIndexes.length ? Math.min(...boundaryIndexes) : remainder.length;
+  return remainder.slice(0, authorityEnd).includes("\\");
 }
 
 function isAllowedUrlCandidate(candidate, urlPolicy) {

--- a/agent-governance-opencode/lib/opencode-policy.mjs
+++ b/agent-governance-opencode/lib/opencode-policy.mjs
@@ -1,0 +1,412 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { isIP } from "node:net";
+
+import {
+  loadPolicy as loadBasePolicy,
+} from "./policy.mjs";
+
+export * from "./policy.mjs";
+
+const DEFAULT_ALLOWLIST_EFFECT = "allow";
+
+/**
+ * Load the existing OpenCode policy and attach positive command/URL allowlists.
+ *
+ * The base policy remains the source for deny/review rules. This layer only
+ * adds a deny result when an explicitly enabled positive allowlist does not
+ * match. PolicyEngine resolves backend decisions with deny precedence, so an
+ * existing deny rule can never be overridden by an allowlist match.
+ */
+export async function loadPolicy(options = {}) {
+  const state = await loadBasePolicy(options);
+
+  try {
+    const positiveAllowlists = compilePositiveAllowlistPolicy(state.policy.raw);
+    state.policy.positiveAllowlists = positiveAllowlists;
+    state.policyEngine.registerBackend(createPositiveAllowlistBackend(positiveAllowlists));
+  } catch (error) {
+    const policyError = error instanceof Error ? error : new Error(String(error));
+    state.policy.positiveAllowlists = emptyPositiveAllowlistPolicy();
+
+    // Preserve the package's existing policy-error contract. In enforce mode,
+    // the normal evaluator path will fail closed before executing a tool. In
+    // advisory mode the invalid extension is ignored and surfaced as a policy
+    // warning instead of silently becoming an active allowlist.
+    if (state.source === "bundled-default") {
+      state.bundledDefaultError ??= policyError;
+    } else {
+      state.configuredPolicyError ??= policyError;
+    }
+  }
+
+  return state;
+}
+
+function compilePositiveAllowlistPolicy(raw) {
+  const commandPatterns = compileRegexPatterns(
+    raw?.toolPolicies?.allowedCommandPatterns,
+    "toolPolicies.allowedCommandPatterns",
+  );
+  const urlPatterns = compileRegexPatterns(
+    raw?.directResourcePolicies?.allowedUrlPatterns,
+    "directResourcePolicies.allowedUrlPatterns",
+  );
+
+  return {
+    commands: {
+      defaultEffect: compileDefaultEffect(
+        raw?.toolPolicies?.commandDefaultEffect,
+        "toolPolicies.commandDefaultEffect",
+      ),
+      patterns: commandPatterns,
+    },
+    urls: {
+      defaultEffect: compileDefaultEffect(
+        raw?.directResourcePolicies?.urlDefaultEffect,
+        "directResourcePolicies.urlDefaultEffect",
+      ),
+      domains: compileAllowedDomains(raw?.directResourcePolicies?.allowedDomains),
+      patterns: urlPatterns,
+    },
+  };
+}
+
+function emptyPositiveAllowlistPolicy() {
+  return {
+    commands: { defaultEffect: DEFAULT_ALLOWLIST_EFFECT, patterns: [] },
+    urls: { defaultEffect: DEFAULT_ALLOWLIST_EFFECT, domains: [], patterns: [] },
+  };
+}
+
+function compileDefaultEffect(value, label) {
+  if (value === undefined || value === null || value === "") {
+    return DEFAULT_ALLOWLIST_EFFECT;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized !== "allow" && normalized !== "deny") {
+    throw new Error(`${label} must be either "allow" or "deny".`);
+  }
+  return normalized;
+}
+
+function compileRegexPatterns(value, label) {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array of regex pattern objects.`);
+  }
+
+  return value.map((pattern, index) => {
+    if (!pattern || typeof pattern !== "object") {
+      throw new Error(`${label}[${index}] must be a regex pattern object.`);
+    }
+    if (typeof pattern.source !== "string" || !pattern.source.trim()) {
+      throw new Error(`${label}[${index}] is missing a non-empty regex source.`);
+    }
+
+    const flags = pattern.flags === undefined ? "" : pattern.flags;
+    if (typeof flags !== "string") {
+      throw new Error(`${label}[${index}].flags must be a string.`);
+    }
+    // Global/sticky regexes mutate lastIndex across calls and would make a
+    // policy decision depend on evaluation history.
+    if (/[gy]/.test(flags)) {
+      throw new Error(`${label}[${index}] must not use stateful g/y regex flags.`);
+    }
+
+    let regex;
+    try {
+      regex = new RegExp(pattern.source, flags);
+    } catch (error) {
+      throw new Error(
+        `${label}[${index}] contains an invalid regular expression: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    return {
+      flags,
+      regex,
+      source: pattern.source,
+    };
+  });
+}
+
+function compileAllowedDomains(value) {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error("directResourcePolicies.allowedDomains must be an array of domain strings.");
+  }
+
+  return value.map((entry, index) => compileAllowedDomain(entry, index));
+}
+
+function compileAllowedDomain(entry, index) {
+  if (typeof entry !== "string" || !entry.trim()) {
+    throw new Error(
+      `directResourcePolicies.allowedDomains[${index}] must be a non-empty domain string.`,
+    );
+  }
+
+  const source = entry.trim().toLowerCase();
+  if (source.includes("://") || /[\s/@?#]/.test(source)) {
+    throw new Error(
+      `directResourcePolicies.allowedDomains[${index}] must contain only a host and optional port.`,
+    );
+  }
+
+  const wildcard = source.startsWith("*.");
+  const hostPort = wildcard ? source.slice(2) : source;
+  if (!hostPort || hostPort.includes("*")) {
+    throw new Error(
+      `directResourcePolicies.allowedDomains[${index}] has an invalid wildcard domain.`,
+    );
+  }
+
+  const port = extractExplicitPort(hostPort, index);
+  let parsed;
+  try {
+    parsed = new URL(`https://${hostPort}`);
+  } catch (error) {
+    throw new Error(
+      `directResourcePolicies.allowedDomains[${index}] is not a valid host/port: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (!hostname) {
+    throw new Error(`directResourcePolicies.allowedDomains[${index}] has no hostname.`);
+  }
+  if (wildcard && isIP(stripIpv6Brackets(hostname))) {
+    throw new Error(
+      `directResourcePolicies.allowedDomains[${index}] cannot apply a wildcard to an IP address.`,
+    );
+  }
+
+  return {
+    hostname,
+    port,
+    source,
+    wildcard,
+  };
+}
+
+function extractExplicitPort(hostPort, index) {
+  if (hostPort.startsWith("[")) {
+    const match = /^\[[^\]]+\](?::(\d+))?$/.exec(hostPort);
+    if (!match) {
+      throw new Error(
+        `directResourcePolicies.allowedDomains[${index}] has an invalid IPv6 host/port.`,
+      );
+    }
+    return normalizePort(match[1], index);
+  }
+
+  const firstColon = hostPort.indexOf(":");
+  const lastColon = hostPort.lastIndexOf(":");
+  if (firstColon !== lastColon) {
+    throw new Error(
+      `directResourcePolicies.allowedDomains[${index}] must bracket IPv6 addresses.`,
+    );
+  }
+  if (lastColon < 0) {
+    return "";
+  }
+
+  const portText = hostPort.slice(lastColon + 1);
+  if (!/^\d+$/.test(portText)) {
+    throw new Error(
+      `directResourcePolicies.allowedDomains[${index}] has a non-numeric port.`,
+    );
+  }
+  return normalizePort(portText, index);
+}
+
+function normalizePort(portText, index) {
+  if (portText === undefined) {
+    return "";
+  }
+  const port = Number(portText);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(
+      `directResourcePolicies.allowedDomains[${index}] has a port outside 1-65535.`,
+    );
+  }
+  return String(port);
+}
+
+function stripIpv6Brackets(hostname) {
+  return hostname.replace(/^\[/, "").replace(/\]$/, "");
+}
+
+function createPositiveAllowlistBackend(policy) {
+  return {
+    name: "agt-positive-allowlists",
+    evaluateAction(action, context) {
+      if (!String(action).startsWith("tool.")) {
+        return "allow";
+      }
+
+      const commandDecision = evaluateCommandAllowlist(policy.commands, context);
+      if (commandDecision) {
+        return commandDecision;
+      }
+
+      const urlDecision = evaluateUrlAllowlist(policy.urls, context);
+      if (urlDecision) {
+        return urlDecision;
+      }
+
+      return "allow";
+    },
+  };
+}
+
+function evaluateCommandAllowlist(commandPolicy, context) {
+  if (commandPolicy.defaultEffect !== "deny") {
+    return null;
+  }
+
+  const command = normalizeCommandText(context.commandText);
+  if (!command) {
+    return null;
+  }
+
+  if (commandPolicy.patterns.some((pattern) => pattern.regex.test(command))) {
+    return null;
+  }
+
+  const toolName = String(context.toolName ?? "unknown");
+  return {
+    backend: "agt-positive-allowlists",
+    decision: "deny",
+    reason: `Command allowlist denied an unapproved command for tool '${toolName}'.`,
+  };
+}
+
+function normalizeCommandText(value) {
+  return String(value ?? "").replace(/\r\n?/g, "\n").trim();
+}
+
+function evaluateUrlAllowlist(urlPolicy, context) {
+  if (urlPolicy.defaultEffect !== "deny") {
+    return null;
+  }
+
+  const candidates = collectHttpUrlCandidates(context.rawToolArgs);
+  for (const candidate of candidates) {
+    if (!candidate.valid) {
+      return {
+        backend: "agt-positive-allowlists",
+        decision: "deny",
+        reason: "URL allowlist denied a malformed HTTP(S) URL in tool arguments.",
+      };
+    }
+
+    if (isAllowedUrlCandidate(candidate, urlPolicy)) {
+      continue;
+    }
+
+    return {
+      backend: "agt-positive-allowlists",
+      decision: "deny",
+      reason: `URL allowlist denied unapproved origin ${candidate.origin}.`,
+    };
+  }
+
+  return null;
+}
+
+function collectHttpUrlCandidates(value) {
+  const candidates = [];
+  const stack = [value];
+  const seenObjects = new WeakSet();
+  const seenUrls = new Set();
+
+  while (stack.length) {
+    const current = stack.pop();
+    if (typeof current === "string") {
+      const raw = current.trim();
+      if (!/^https?:\/\//i.test(raw)) {
+        continue;
+      }
+
+      let candidate;
+      try {
+        const url = new URL(raw);
+        if (url.protocol !== "http:" && url.protocol !== "https:") {
+          continue;
+        }
+        candidate = {
+          normalizedUrl: url.toString(),
+          origin: url.origin,
+          url,
+          valid: true,
+        };
+      } catch {
+        candidate = { valid: false };
+      }
+
+      const key = candidate.valid ? candidate.normalizedUrl : `invalid:${raw}`;
+      if (!seenUrls.has(key)) {
+        seenUrls.add(key);
+        candidates.push(candidate);
+      }
+      continue;
+    }
+
+    if (!current || typeof current !== "object") {
+      continue;
+    }
+    if (seenObjects.has(current)) {
+      continue;
+    }
+    seenObjects.add(current);
+
+    if (Array.isArray(current)) {
+      stack.push(...current);
+    } else {
+      stack.push(...Object.values(current));
+    }
+  }
+
+  return candidates;
+}
+
+function isAllowedUrlCandidate(candidate, urlPolicy) {
+  if (urlPolicy.patterns.some((pattern) => pattern.regex.test(candidate.normalizedUrl))) {
+    return true;
+  }
+  return urlPolicy.domains.some((domain) => domainMatches(domain, candidate.url));
+}
+
+function domainMatches(domain, url) {
+  const hostname = url.hostname.toLowerCase();
+  const hostMatches = domain.wildcard
+    ? hostname !== domain.hostname && hostname.endsWith(`.${domain.hostname}`)
+    : hostname === domain.hostname;
+  if (!hostMatches) {
+    return false;
+  }
+
+  if (!domain.port) {
+    return true;
+  }
+  return effectiveUrlPort(url) === domain.port;
+}
+
+function effectiveUrlPort(url) {
+  if (url.port) {
+    return url.port;
+  }
+  return url.protocol === "https:" ? "443" : "80";
+}

--- a/agent-governance-opencode/package.json
+++ b/agent-governance-opencode/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.mjs",
   "exports": {
     ".": "./src/index.mjs",
-    "./policy": "./lib/policy.mjs",
+    "./policy": "./lib/opencode-policy.mjs",
     "./mcp-server": "./server/agt-mcp.mjs"
   },
   "files": [
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "npm run check",
-    "check": "node --check ./src/index.mjs && node --check ./lib/audit.mjs && node --check ./lib/poisoning.mjs && node --check ./lib/policy.mjs && node --check ./server/agt-mcp.mjs && node --test ./test/*.test.mjs",
+    "check": "node --check ./src/index.mjs && node --check ./lib/audit.mjs && node --check ./lib/poisoning.mjs && node --check ./lib/policy.mjs && node --check ./lib/opencode-policy.mjs && node --check ./server/agt-mcp.mjs && node --test ./test/*.test.mjs",
     "test": "node --test ./test/*.test.mjs"
   },
   "keywords": [

--- a/agent-governance-opencode/server/agt-mcp.mjs
+++ b/agent-governance-opencode/server/agt-mcp.mjs
@@ -4,7 +4,7 @@
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-import { checkArbitraryText, getPolicyStatus, loadPolicy } from "../lib/policy.mjs";
+import { checkArbitraryText, getPolicyStatus, loadPolicy } from "../lib/opencode-policy.mjs";
 
 const VERSION = "3.6.0";
 const PROTOCOL_VERSION = "2024-11-05";

--- a/agent-governance-opencode/src/index.mjs
+++ b/agent-governance-opencode/src/index.mjs
@@ -8,7 +8,7 @@ import {
   evaluateOpenCodeToolOutput,
   getPolicyStatus,
   loadPolicy,
-} from "../lib/policy.mjs";
+} from "../lib/opencode-policy.mjs";
 
 /**
  * AGT governance plugin for OpenCode.
@@ -151,9 +151,9 @@ export const AgtGovernance = async (ctx) => {
       agt_policy_check_text: {
         description:
           "Check text against AGT prompt, context-poisoning, and MCP-style threat detectors.",
-          args: {
-            text: { type: "string", description: "Text to inspect." },
-          },
+        args: {
+          text: { type: "string", description: "Text to inspect." },
+        },
         async execute(args) {
           const state = await getState();
           const text = typeof args?.text === "string" ? args.text : "";

--- a/agent-governance-opencode/test/allowlist-policy.test.mjs
+++ b/agent-governance-opencode/test/allowlist-policy.test.mjs
@@ -305,6 +305,36 @@ test("URL allowlist cannot override a direct-resource deny", async () => {
   );
 });
 
+test("canonicalized direct-resource denies apply when URL allowlists are disabled", async () => {
+  await withPolicy(
+    makePolicy({
+      directResourcePolicies: {
+        urlRules: [
+          {
+            id: "metadata",
+            effect: "deny",
+            reason: "Metadata endpoint remains blocked.",
+            urlPatterns: [
+              { source: "^http://169\\.254\\.169\\.254(?:/|$)", flags: "i" },
+            ],
+          },
+        ],
+      },
+    }),
+    async (state, root) => {
+      const result = await evaluateOpenCodeTool(state, {
+        tool: "webfetch",
+        args: { url: String.raw`http:\\169.254.169.254\latest\meta-data` },
+        cwd: root,
+        sessionId: "metadata-deny-without-url-allowlist",
+      });
+
+      assert.equal(result.effect, "deny");
+      assert.match(result.reason, /metadata endpoint remains blocked/i);
+    },
+  );
+});
+
 test("invalid positive-allowlist configuration is a fail-closed policy error", async () => {
   await withPolicy(
     makePolicy({

--- a/agent-governance-opencode/test/allowlist-policy.test.mjs
+++ b/agent-governance-opencode/test/allowlist-policy.test.mjs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -82,6 +82,80 @@ test("command allowlist normalizes outer whitespace and denies unmatched command
       });
       assert.equal(denied.effect, "deny");
       assert.match(denied.reason, /command allowlist denied/i);
+    },
+  );
+});
+
+test("shipped allowlist example denies command chaining and substitution", async () => {
+  const example = JSON.parse(
+    await readFile(new URL("../config/allowlist-policy.example.json", import.meta.url), "utf8"),
+  );
+
+  await withPolicy(example, async (state, root) => {
+    for (const command of [
+      "git status ; echo chained",
+      "git status && echo chained",
+      "git status\nprintf chained",
+      "git status $(printf chained)",
+      "git status `printf chained`",
+    ]) {
+      const result = await evaluateOpenCodeTool(state, {
+        tool: "bash",
+        args: { command },
+        cwd: root,
+        sessionId: `example-command-deny-${command}`,
+      });
+      assert.equal(result.effect, "deny", command);
+      assert.match(result.reason, /command allowlist denied/i);
+    }
+  });
+});
+
+test("command allowlist evaluates every present command argument key", async () => {
+  await withPolicy(
+    makePolicy({
+      toolPolicies: {
+        commandDefaultEffect: "deny",
+        allowedCommandPatterns: [{ source: "^git status$", flags: "i" }],
+      },
+    }),
+    async (state, root) => {
+      for (const args of [
+        { command: "git status", script: "npm publish" },
+        { cmd: "npm publish", command: "git status" },
+      ]) {
+        const result = await evaluateOpenCodeTool(state, {
+          tool: "bash",
+          args,
+          cwd: root,
+          sessionId: `multi-command-key-${JSON.stringify(args)}`,
+        });
+        assert.equal(result.effect, "deny");
+        assert.match(result.reason, /command allowlist denied/i);
+      }
+    },
+  );
+});
+
+test("command allowlist denies non-string command argument values", async () => {
+  await withPolicy(
+    makePolicy({
+      toolPolicies: {
+        commandDefaultEffect: "deny",
+        allowedCommandPatterns: [{ source: "^git status$", flags: "i" }],
+      },
+    }),
+    async (state, root) => {
+      for (const command of [["rm", "-rf", "/"], 42, { executable: "rm" }, null]) {
+        const result = await evaluateOpenCodeTool(state, {
+          tool: "bash",
+          args: { command },
+          cwd: root,
+          sessionId: `malformed-command-${JSON.stringify(command)}`,
+        });
+        assert.equal(result.effect, "deny");
+        assert.match(result.reason, /malformed command arguments/i);
+      }
     },
   );
 });
@@ -176,6 +250,7 @@ test("URL allowlist supports exact hosts, wildcard subdomains, URL patterns, and
     async (state, root) => {
       for (const url of [
         "https://api.github.com/repos/microsoft/agent-governance-toolkit",
+        "http://api.github.com/repos/microsoft/agent-governance-toolkit",
         "https://build.example.com/artifacts",
         "https://deep.build.example.com/artifacts",
         "https://internal.example.net:8443/v1",
@@ -220,15 +295,15 @@ test("URL default deny canonicalizes alternate HTTP(S) spellings", async () => {
     async (state, root) => {
       const allowed = await evaluateOpenCodeTool(state, {
         tool: "webfetch",
-        args: { url: String.raw`https:\\api.github.com/repos/microsoft/agent-governance-toolkit` },
+        args: { url: "https:/api.github.com/repos/microsoft/agent-governance-toolkit" },
         cwd: root,
         sessionId: "url-canonicalized-allow",
       });
       assert.equal(allowed.effect, "allow");
 
       for (const url of [
-        String.raw`https:\\collector.invalid/next`,
         "https:/collector.invalid/next",
+        "https:collector.invalid/next",
       ]) {
         const denied = await evaluateOpenCodeTool(state, {
           tool: "webfetch",
@@ -238,6 +313,32 @@ test("URL default deny canonicalizes alternate HTTP(S) spellings", async () => {
         });
         assert.equal(denied.effect, "deny", url);
         assert.match(denied.reason, /collector\.invalid/i);
+      }
+    },
+  );
+});
+
+test("URL governance rejects backslashes in the raw HTTP(S) authority", async () => {
+  await withPolicy(
+    makePolicy({
+      directResourcePolicies: {
+        urlDefaultEffect: "deny",
+        allowedDomains: ["api.github.com"],
+      },
+    }),
+    async (state, root) => {
+      for (const url of [
+        String.raw`https://api.github.com\@evil.com/`,
+        String.raw`https:\\api.github.com/repos/microsoft/agent-governance-toolkit`,
+      ]) {
+        const result = await evaluateOpenCodeTool(state, {
+          tool: "webfetch",
+          args: { url },
+          cwd: root,
+          sessionId: `url-authority-backslash-${url}`,
+        });
+        assert.equal(result.effect, "deny", url);
+        assert.match(result.reason, /ambiguous.*backslash/i);
       }
     },
   );
@@ -289,7 +390,7 @@ test("URL allowlist cannot override a direct-resource deny", async () => {
     async (state, root) => {
       for (const url of [
         "http://169.254.169.254/latest/meta-data/",
-        String.raw`http:\\169.254.169.254\latest\meta-data`,
+        "http:169.254.169.254/latest/meta-data/",
       ]) {
         const result = await evaluateOpenCodeTool(state, {
           tool: "webfetch",
@@ -324,7 +425,7 @@ test("canonicalized direct-resource denies apply when URL allowlists are disable
     async (state, root) => {
       const result = await evaluateOpenCodeTool(state, {
         tool: "webfetch",
-        args: { url: String.raw`http:\\169.254.169.254\latest\meta-data` },
+        args: { url: "http:169.254.169.254/latest/meta-data/" },
         cwd: root,
         sessionId: "metadata-deny-without-url-allowlist",
       });
@@ -378,19 +479,22 @@ test("domain validation rejects URL-parser separator ambiguities", async () => {
   );
 });
 
-test("stateful regex flags are rejected to keep allowlist decisions deterministic", async () => {
-  await withPolicy(
-    makePolicy({
-      toolPolicies: {
-        commandDefaultEffect: "deny",
-        allowedCommandPatterns: [{ source: "^git status$", flags: "g" }],
+test("unsafe regex flags are rejected for allowlist patterns", async () => {
+  for (const flags of ["g", "y", "m", "s"]) {
+    await withPolicy(
+      makePolicy({
+        toolPolicies: {
+          commandDefaultEffect: "deny",
+          allowedCommandPatterns: [{ source: "^git status$", flags }],
+        },
+      }),
+      async (state) => {
+        assert.match(
+          state.configuredPolicyError?.message ?? "",
+          /must not use g\/y\/m\/s regex flags/i,
+          flags,
+        );
       },
-    }),
-    async (state) => {
-      assert.match(
-        state.configuredPolicyError?.message ?? "",
-        /must not use stateful g\/y regex flags/i,
-      );
-    },
-  );
+    );
+  }
 });

--- a/agent-governance-opencode/test/allowlist-policy.test.mjs
+++ b/agent-governance-opencode/test/allowlist-policy.test.mjs
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  evaluateOpenCodeTool,
+  loadPolicy,
+} from "../lib/opencode-policy.mjs";
+
+function makePolicy(overrides = {}) {
+  const toolPolicies = {
+    allowedTools: ["bash", "webfetch"],
+    blockedTools: [],
+    defaultEffect: "allow",
+    reviewTools: [],
+    ...(overrides.toolPolicies ?? {}),
+  };
+  const directResourcePolicies = {
+    pathRules: [],
+    urlRules: [],
+    ...(overrides.directResourcePolicies ?? {}),
+  };
+
+  return {
+    schemaVersion: 1,
+    version: 1,
+    mode: "enforce",
+    denyOnPolicyError: true,
+    minimumPromptDefenseGrade: "B",
+    additionalContext: [],
+    blockedToolCalls: [],
+    poisoningPatterns: [],
+    ...overrides,
+    toolPolicies,
+    directResourcePolicies,
+  };
+}
+
+async function withPolicy(raw, callback) {
+  const root = await mkdtemp(join(tmpdir(), "agt-opencode-allowlist-"));
+  const policyPath = join(root, "policy.json");
+  const auditPath = join(root, "audit.json");
+  await writeFile(policyPath, JSON.stringify(raw, null, 2), "utf8");
+
+  try {
+    const state = await loadPolicy({ policyPath, auditPath, homeDirectory: root });
+    await callback(state, root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test("command allowlist normalizes outer whitespace and denies unmatched commands", async () => {
+  await withPolicy(
+    makePolicy({
+      toolPolicies: {
+        commandDefaultEffect: "deny",
+        allowedCommandPatterns: [
+          { source: "^git\\s+status$", flags: "i" },
+        ],
+      },
+    }),
+    async (state, root) => {
+      const allowed = await evaluateOpenCodeTool(state, {
+        tool: "bash",
+        args: { command: "  \r\ngit status\r\n  " },
+        cwd: root,
+        sessionId: "command-allow",
+      });
+      assert.equal(allowed.effect, "allow");
+
+      const denied = await evaluateOpenCodeTool(state, {
+        tool: "bash",
+        args: { command: "npm publish" },
+        cwd: root,
+        sessionId: "command-deny",
+      });
+      assert.equal(denied.effect, "deny");
+      assert.match(denied.reason, /command allowlist denied/i);
+    },
+  );
+});
+
+test("command allowlist does not override an existing deny rule", async () => {
+  await withPolicy(
+    makePolicy({
+      toolPolicies: {
+        commandDefaultEffect: "deny",
+        allowedCommandPatterns: [{ source: "^[\\s\\S]+$" }],
+      },
+      blockedToolCalls: [
+        {
+          id: "blocked-marker",
+          tool: "bash",
+          effect: "deny",
+          reason: "Custom deny rule won.",
+          commandPatterns: [{ source: "forbidden-marker", flags: "i" }],
+        },
+      ],
+    }),
+    async (state, root) => {
+      const result = await evaluateOpenCodeTool(state, {
+        tool: "bash",
+        args: { command: "echo forbidden-marker" },
+        cwd: root,
+        sessionId: "deny-wins",
+      });
+
+      assert.equal(result.effect, "deny");
+      assert.match(result.reason, /custom deny rule won/i);
+    },
+  );
+});
+
+test("URL allowlist supports exact hosts, wildcard subdomains, URL patterns, and ports", async () => {
+  await withPolicy(
+    makePolicy({
+      directResourcePolicies: {
+        urlDefaultEffect: "deny",
+        allowedDomains: [
+          "api.github.com",
+          "*.example.com",
+          "internal.example.net:8443",
+        ],
+        allowedUrlPatterns: [
+          { source: "^https://status\\.example\\.net/health(?:\\?|$)", flags: "i" },
+        ],
+      },
+    }),
+    async (state, root) => {
+      for (const url of [
+        "https://api.github.com/repos/microsoft/agent-governance-toolkit",
+        "https://build.example.com/artifacts",
+        "https://deep.build.example.com/artifacts",
+        "https://internal.example.net:8443/v1",
+        "https://status.example.net/health?full=1",
+      ]) {
+        const result = await evaluateOpenCodeTool(state, {
+          tool: "webfetch",
+          args: { url },
+          cwd: root,
+          sessionId: `allowed-${url}`,
+        });
+        assert.equal(result.effect, "allow", url);
+      }
+
+      for (const url of [
+        "https://example.com/",
+        "https://api.github.com.evil.invalid/",
+        "https://internal.example.net:9443/v1",
+        "https://status.example.net/private",
+      ]) {
+        const result = await evaluateOpenCodeTool(state, {
+          tool: "webfetch",
+          args: { url },
+          cwd: root,
+          sessionId: `denied-${url}`,
+        });
+        assert.equal(result.effect, "deny", url);
+        assert.match(result.reason, /url allowlist denied/i);
+      }
+    },
+  );
+});
+
+test("URL default deny checks every URL-valued argument including redirect targets", async () => {
+  await withPolicy(
+    makePolicy({
+      directResourcePolicies: {
+        urlDefaultEffect: "deny",
+        allowedDomains: ["api.github.com"],
+      },
+    }),
+    async (state, root) => {
+      const result = await evaluateOpenCodeTool(state, {
+        tool: "webfetch",
+        args: {
+          url: "https://api.github.com/start",
+          redirectUrl: "https://collector.invalid/next",
+        },
+        cwd: root,
+        sessionId: "redirect-deny",
+      });
+
+      assert.equal(result.effect, "deny");
+      assert.match(result.reason, /collector\.invalid/i);
+    },
+  );
+});
+
+test("URL allowlist cannot override a direct-resource deny", async () => {
+  await withPolicy(
+    makePolicy({
+      directResourcePolicies: {
+        urlDefaultEffect: "deny",
+        allowedDomains: ["169.254.169.254"],
+        urlRules: [
+          {
+            id: "metadata",
+            effect: "deny",
+            reason: "Metadata endpoint remains blocked.",
+            urlPatterns: [
+              { source: "^http://169\\.254\\.169\\.254(?:/|$)", flags: "i" },
+            ],
+          },
+        ],
+      },
+    }),
+    async (state, root) => {
+      const result = await evaluateOpenCodeTool(state, {
+        tool: "webfetch",
+        args: { url: "http://169.254.169.254/latest/meta-data/" },
+        cwd: root,
+        sessionId: "metadata-deny",
+      });
+
+      assert.equal(result.effect, "deny");
+      assert.match(result.reason, /metadata endpoint remains blocked/i);
+    },
+  );
+});
+
+test("invalid positive-allowlist configuration is a fail-closed policy error", async () => {
+  await withPolicy(
+    makePolicy({
+      directResourcePolicies: {
+        urlDefaultEffect: "deny",
+        allowedDomains: ["https://example.com"],
+      },
+    }),
+    async (state, root) => {
+      assert.match(
+        state.configuredPolicyError?.message ?? "",
+        /allowedDomains.*host and optional port/i,
+      );
+
+      const result = await evaluateOpenCodeTool(state, {
+        tool: "webfetch",
+        args: { url: "https://example.com/" },
+        cwd: root,
+        sessionId: "invalid-policy",
+      });
+      assert.equal(result.effect, "deny");
+      assert.match(result.reason, /policy could not be loaded/i);
+    },
+  );
+});
+
+test("stateful regex flags are rejected to keep allowlist decisions deterministic", async () => {
+  await withPolicy(
+    makePolicy({
+      toolPolicies: {
+        commandDefaultEffect: "deny",
+        allowedCommandPatterns: [{ source: "^git status$", flags: "g" }],
+      },
+    }),
+    async (state) => {
+      assert.match(
+        state.configuredPolicyError?.message ?? "",
+        /must not use stateful g\/y regex flags/i,
+      );
+    },
+  );
+});

--- a/agent-governance-opencode/test/allowlist-policy.test.mjs
+++ b/agent-governance-opencode/test/allowlist-policy.test.mjs
@@ -86,6 +86,47 @@ test("command allowlist normalizes outer whitespace and denies unmatched command
   );
 });
 
+test("command allowlist is limited to command-bearing tool calls", async () => {
+  await withPolicy(
+    makePolicy({
+      toolPolicies: {
+        commandDefaultEffect: "deny",
+        allowedCommandPatterns: [{ source: "^git\\s+status$", flags: "i" }],
+      },
+      directResourcePolicies: {
+        urlDefaultEffect: "deny",
+        allowedDomains: ["api.github.com"],
+      },
+    }),
+    async (state, root) => {
+      const webfetch = await evaluateOpenCodeTool(state, {
+        tool: "webfetch",
+        args: { url: "https://api.github.com/repos/microsoft/agent-governance-toolkit" },
+        cwd: root,
+        sessionId: "command-scope-webfetch",
+      });
+      assert.equal(webfetch.effect, "allow");
+
+      const allowedInput = await evaluateOpenCodeTool(state, {
+        tool: "bash",
+        args: { input: "git status" },
+        cwd: root,
+        sessionId: "command-scope-bash-input-allow",
+      });
+      assert.equal(allowedInput.effect, "allow");
+
+      const deniedInput = await evaluateOpenCodeTool(state, {
+        tool: "bash",
+        args: { input: "npm publish" },
+        cwd: root,
+        sessionId: "command-scope-bash-input-deny",
+      });
+      assert.equal(deniedInput.effect, "deny");
+      assert.match(deniedInput.reason, /command allowlist denied/i);
+    },
+  );
+});
+
 test("command allowlist does not override an existing deny rule", async () => {
   await withPolicy(
     makePolicy({
@@ -168,6 +209,40 @@ test("URL allowlist supports exact hosts, wildcard subdomains, URL patterns, and
   );
 });
 
+test("URL default deny canonicalizes alternate HTTP(S) spellings", async () => {
+  await withPolicy(
+    makePolicy({
+      directResourcePolicies: {
+        urlDefaultEffect: "deny",
+        allowedDomains: ["api.github.com"],
+      },
+    }),
+    async (state, root) => {
+      const allowed = await evaluateOpenCodeTool(state, {
+        tool: "webfetch",
+        args: { url: String.raw`https:\\api.github.com/repos/microsoft/agent-governance-toolkit` },
+        cwd: root,
+        sessionId: "url-canonicalized-allow",
+      });
+      assert.equal(allowed.effect, "allow");
+
+      for (const url of [
+        String.raw`https:\\collector.invalid/next`,
+        "https:/collector.invalid/next",
+      ]) {
+        const denied = await evaluateOpenCodeTool(state, {
+          tool: "webfetch",
+          args: { url },
+          cwd: root,
+          sessionId: `url-canonicalized-deny-${url}`,
+        });
+        assert.equal(denied.effect, "deny", url);
+        assert.match(denied.reason, /collector\.invalid/i);
+      }
+    },
+  );
+});
+
 test("URL default deny checks every URL-valued argument including redirect targets", async () => {
   await withPolicy(
     makePolicy({
@@ -212,15 +287,20 @@ test("URL allowlist cannot override a direct-resource deny", async () => {
       },
     }),
     async (state, root) => {
-      const result = await evaluateOpenCodeTool(state, {
-        tool: "webfetch",
-        args: { url: "http://169.254.169.254/latest/meta-data/" },
-        cwd: root,
-        sessionId: "metadata-deny",
-      });
+      for (const url of [
+        "http://169.254.169.254/latest/meta-data/",
+        String.raw`http:\\169.254.169.254\latest\meta-data`,
+      ]) {
+        const result = await evaluateOpenCodeTool(state, {
+          tool: "webfetch",
+          args: { url },
+          cwd: root,
+          sessionId: `metadata-deny-${url}`,
+        });
 
-      assert.equal(result.effect, "deny");
-      assert.match(result.reason, /metadata endpoint remains blocked/i);
+        assert.equal(result.effect, "deny", url);
+        assert.match(result.reason, /metadata endpoint remains blocked/i);
+      }
     },
   );
 });
@@ -247,6 +327,23 @@ test("invalid positive-allowlist configuration is a fail-closed policy error", a
       });
       assert.equal(result.effect, "deny");
       assert.match(result.reason, /policy could not be loaded/i);
+    },
+  );
+});
+
+test("domain validation rejects URL-parser separator ambiguities", async () => {
+  await withPolicy(
+    makePolicy({
+      directResourcePolicies: {
+        urlDefaultEffect: "deny",
+        allowedDomains: [String.raw`example.com\unexpected`],
+      },
+    }),
+    async (state) => {
+      assert.match(
+        state.configuredPolicyError?.message ?? "",
+        /allowedDomains.*host and optional port/i,
+      );
     },
   );
 });


### PR DESCRIPTION
## Summary

Add opt-in positive command and URL/domain allowlists to the OpenCode governance policy surface, closing #3666.

## Problem

OpenCode currently supports negative controls through `blockedToolCalls[].commandPatterns` and `directResourcePolicies.urlRules`, but cannot express policies such as “only these commands” or “only these network destinations” with an explicit default-deny posture.

## Changes

- add `toolPolicies.allowedCommandPatterns` and `commandDefaultEffect`
- add `directResourcePolicies.allowedDomains`, `allowedUrlPatterns`, and `urlDefaultEffect`
- support exact hosts, `*.example.com` subdomains, and optional explicit ports
- preserve deny precedence so a positive match can never override an existing deny
- reject malformed domains, invalid regexes, unsupported default effects, and stateful `g`/`y` regex flags
- normalize outer command whitespace and CRLF line endings before matching
- route invalid allowlist configuration through the existing `denyOnPolicyError` behavior
- wire the OpenCode plugin, public `./policy` export, and bundled MCP server through the OpenCode-specific allowlist layer
- add an opt-in example and focused regression tests

## Security and compatibility

The positive allowlist controls are opt-in: both new default effects remain `allow` unless explicitly changed to `deny`. Separately, this PR tightens existing URL-rule handling: surfaced HTTP(S) forms such as `https:host` are canonicalized before existing `urlRules` are evaluated, and ambiguous HTTP(S) authorities containing backslashes are denied even when `urlDefaultEffect` is `allow`.

The positive layer can only add a deny. `PolicyEngine` already resolves backend decisions with `deny` taking precedence over `review` and `allow`.

For URLs, every HTTP(S) value surfaced as a tool argument is checked, so an allowed primary URL does not authorize a separate unapproved redirect-target argument. Redirects hidden inside an HTTP client remain outside the plugin hook boundary.

No runtime dependency is added.

## Testing

Added `agent-governance-opencode/test/allowlist-policy.test.mjs` and wired it into the package's existing `npm run check` / `npm test` glob.

Closes #3666