### PR TITLE
fix(agent-os): enforce TLS for configured MCP URLs

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
@@ -118,7 +118,8 @@ class McpAuthPolicy:
         Args:
             server_name: Name of the MCP server.
             auth_method: Authentication method being used.
-            url: Server URL (for logging/audit).
+            url: Server URL used for TLS enforcement. When omitted, the
+                configured server entry URL is used.
 
         Returns:
             AuthCheckResult indicating whether the connection is allowed.
@@ -152,9 +153,12 @@ class McpAuthPolicy:
                 # all bypassed the require_tls gate because none of
                 # them start with "http://" — only `https://` and
                 # `wss://` represent actual TLS-secured transports.
-                if entry.require_tls and url:
+                # The caller URL describes the connection being checked and
+                # therefore takes precedence over the configured fallback.
+                effective_url = url or entry.url
+                if entry.require_tls and effective_url:
                     try:
-                        scheme = urlparse(url).scheme.lower()
+                        scheme = urlparse(effective_url).scheme.lower()
                     except (ValueError, AttributeError):
                         scheme = ""
                     if scheme not in {"https", "wss"}:

--- a/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
@@ -90,6 +90,64 @@ class TestMcpAuthPolicy:
         # HTTP rejected
         assert not policy.check("secure", auth_method="oauth2", url="http://api.example.com").allowed
 
+    @pytest.mark.parametrize("require_tls", [True, False], ids=["tls-required", "tls-not-required"])
+    @pytest.mark.parametrize(
+        ("caller_url", "configured_url", "allowed_when_tls_required"),
+        [
+            pytest.param("", "", True, id="empty-caller-empty-config"),
+            pytest.param("", "https://configured.example", True, id="empty-caller-https-config"),
+            pytest.param("", "http://configured.example", False, id="empty-caller-http-config"),
+            pytest.param("https://caller.example", "", True, id="https-caller-empty-config"),
+            pytest.param(
+                "https://caller.example",
+                "https://configured.example",
+                True,
+                id="https-caller-https-config",
+            ),
+            pytest.param(
+                "https://caller.example",
+                "http://configured.example",
+                True,
+                id="https-caller-http-config",
+            ),
+            pytest.param("http://caller.example", "", False, id="http-caller-empty-config"),
+            pytest.param(
+                "http://caller.example",
+                "https://configured.example",
+                False,
+                id="http-caller-https-config",
+            ),
+            pytest.param(
+                "http://caller.example",
+                "http://configured.example",
+                False,
+                id="http-caller-http-config",
+            ),
+        ],
+    )
+    def test_tls_enforcement_uses_caller_url_or_configured_fallback(
+        self,
+        require_tls,
+        caller_url,
+        configured_url,
+        allowed_when_tls_required,
+    ):
+        policy = McpAuthPolicy(
+            servers=[
+                McpServerEntry(
+                    name="secure",
+                    url=configured_url,
+                    allowed_auth_methods=["oauth2"],
+                    require_tls=require_tls,
+                ),
+            ]
+        )
+
+        result = policy.check("secure", auth_method="oauth2", url=caller_url)
+
+        expected_allowed = allowed_when_tls_required if require_tls else True
+        assert result.allowed is expected_allowed
+
     def test_add_remove_server(self):
         policy = McpAuthPolicy()
         policy.add_server(McpServerEntry(name="new", allowed_auth_methods=["api_key"]))


### PR DESCRIPTION
## Related Issue

Fixes #3785

## Problem & Solution

`McpAuthPolicy.check()` enforced `require_tls` only against the URL supplied by the caller. When the caller omitted that argument, a non-TLS URL already stored in the matching `McpServerEntry` was never evaluated.

This PR selects the effective URL as the caller URL or the configured entry URL. The caller URL retains priority because it describes the connection being checked. If both sources are empty, the existing behavior remains unchanged and the TLS gate is skipped, preserving S10.12 compatibility.

## Impact on Your Work

Configured MCP server URLs now receive the same TLS scheme enforcement as caller-supplied URLs.

## Timeline

None.

## Alternatives Considered

- Requiring every caller to repeat the configured URL would leave the configuration path unenforced.
- Rejecting entries when both URL sources are empty would change the existing S10.12 conformance behavior and is outside the scope of this fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected

**Core & runtime:**
- [ ] agent-governance-toolkit-core
- [ ] agent-primitives
- [x] agent-os
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-compliance

**Governance & security:**
- [ ] agent-mcp-governance
- [ ] agent-rag-governance
- [ ] agent-sandbox
- [ ] agent-discovery
- [ ] agt-policies
- [ ] policy-engine

**Platform & tooling:**
- [ ] agent-hypervisor
- [ ] agent-lightning
- [ ] agent-marketplace
- [ ] agent-governance-toolkit-cli
- [ ] agent-governance-toolkit-integrations
- [ ] agent-governance-toolkit-protocols
- [ ] agentmesh-integrations (framework integrations)

**CLI plugins:**
- [ ] agent-governance CLI plugins (copilot-cli / claude-code / opencode / antigravity-cli)

**Shared / other:**
- [ ] schemas
- [ ] action (GitHub Action)
- [ ] examples
- [ ] docs / root

## Testing

### Unit Testing

Added an 18-case parameterized matrix covering:

- `require_tls=True` and `False`
- empty, HTTPS, and HTTP caller URLs
- empty, HTTPS, and HTTP configured entry URLs
- caller URL precedence
- the compatible empty-both-sources behavior

### Manual Testing

```text
pytest agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py -q
35 passed, 1 deprecation warning
```

`git diff --check` passes. Ruff reports the same four existing file-level findings as `main`; none are introduced by the changed lines. The direct conformance module was not collectable in this local checkout because the compiled `agent_control_specification._native` module is unavailable; the regression matrix directly pins the S10.12 empty-both behavior.

## Checklist

- [x] I have linked a related issue above, or completed "Problem & Solution", "Impact on Your Work", and "Alternatives Considered"
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest) — the scoped suite passes; the full package suite was not run locally
- [x] I have updated documentation as needed
- [ ] I have signed the Microsoft CLA — pending CLA bot verification

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

The configured-URL fallback was previously discussed within this repository in #3512 and was raised again in #3785. No external project code was copied or adapted.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

Codex was used to inspect the issue, draft the regression matrix and minimal patch, and prepare this PR text. All changes were reviewed and explicitly approved by the contributor before submission.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License
