### PR TITLE
fix(agt-policies): use array-path accessors for nested fields

### DIFF
--- a/agent-governance-python/agt-policies/src/agt/cli/_migrate_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/cli/_migrate_resolution/build.py
@@ -346,7 +346,15 @@ def _rego_op_clause(
     literal = json.dumps(value)
     indent = "    "
     if operator == "eq":
-        return f"{indent}{accessor} == {literal}"
+        # The array-path accessor resolves a missing path to null, so an
+        # unguarded ``eq: null`` matches every input that omits the field --
+        # absence on both sides of the comparison reads as agreement. On the
+        # allow side that is fail-open: a rule written to allow an explicit
+        # null also allows anything missing the field, preempting a later
+        # deny. Guard allow the same way ``ne`` and ``not_in`` are guarded;
+        # deny keeps the unguarded form so a missing path still trips it.
+        null_guard = "" if action == "deny" else f"\n{indent}_v != null"
+        return f"{indent}_v := {accessor}{null_guard}\n{indent}_v == {literal}"
     if operator == "ne":
         # Missing paths resolve to null via the array-path accessor. Keep
         # ``null != value`` as a match so deny-side ``ne`` fails closed when

--- a/agent-governance-python/agt-policies/src/agt/cli/_migrate_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/cli/_migrate_resolution/build.py
@@ -243,7 +243,11 @@ def _render_rego(rules: list[dict[str, Any]]) -> str:
         message = str(rule.get("message", ""))
 
         accessor = _rego_field_accessor(field)
-        op_clause = _rego_op_clause(operator, accessor, value) if accessor is not None else None
+        op_clause = (
+            _rego_op_clause(operator, accessor, value, action=action)
+            if accessor is not None
+            else None
+        )
         if op_clause is None:
             # Unsupported operators or invalid field paths MUST fail
             # closed. Render an always-matching deny rule so evaluation
@@ -332,7 +336,9 @@ def _rego_field_accessor(field: str) -> str | None:
     return f"object.get(input.snapshot, {json.dumps(parts)}, null)"
 
 
-def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
+def _rego_op_clause(
+    operator: str, accessor: str, value: Any, *, action: str
+) -> Optional[str]:
     """Render the body of a `_match[i]` rule for a given operator.
 
     Returns None for unsupported operators; the caller turns the rule into a fail-closed deny.
@@ -345,7 +351,8 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
         # Missing paths resolve to null via the array-path accessor. Keep
         # ``null != value`` as a match so deny-side ``ne`` fails closed when
         # intermediate segments are omitted (#3360).
-        return f"{indent}_v := {accessor}\n{indent}_v != {literal}"
+        null_guard = "" if action == "deny" else f"\n{indent}_v != null"
+        return f"{indent}_v := {accessor}{null_guard}\n{indent}_v != {literal}"
     if operator == "gt":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v > {literal}"
     if operator == "lt":
@@ -359,7 +366,8 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "not_in":
         # Same fail-closed posture as ``ne``: a missing path (null) is not a
         # member of the allowlist, so ``not_in`` matches (#3360).
-        return f"{indent}_v := {accessor}\n{indent}not _v in {literal}"
+        null_guard = "" if action == "deny" else f"\n{indent}_v != null"
+        return f"{indent}_v := {accessor}{null_guard}\n{indent}not _v in {literal}"
     if operator == "exists":
         return f"{indent}{accessor} != null"
     if operator == "contains":

--- a/agent-governance-python/agt-policies/src/agt/cli/_migrate_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/cli/_migrate_resolution/build.py
@@ -312,24 +312,24 @@ def _rego_field_accessor(field: str) -> str | None:
             ``envelope.budgets.tool_call_count``.
 
     Returns:
-        Rego source like ``input.snapshot.tool_call.args.amount_usd``.
-        Each segment is checked with ``object.get`` so missing fields
-        evaluate to undefined (matches §5.2 of the ACS spec on missing
-        fields).
+        Rego source like
+        ``object.get(input.snapshot, ["tool_call", "args", "amount_usd"], null)``.
+
+        The array-path form of ``object.get`` yields the null default when a
+        leaf *or* an intermediate segment is missing. Chained
+        ``object.get(object.get(...), ...)`` returns undefined (not null) when
+        a parent is absent, which made deny ``ne`` / ``not_in`` rules fail open
+        (see microsoft/agent-governance-toolkit#3360).
     """
     parts = [p for p in field.split(".") if p]
     if not parts:
         return "input.snapshot"
-    # Use chained object.get with a sentinel undefined value so each
-    # level fails closed when the field is absent.
-    expr = "input.snapshot"
     for part in parts:
         # Validate the part is a simple identifier; reject anything
         # weird to avoid Rego injection from policy authors.
         if not part.replace("_", "").isalnum():
             return None
-        expr = f"object.get({expr}, {json.dumps(part)}, null)"
-    return expr
+    return f"object.get(input.snapshot, {json.dumps(parts)}, null)"
 
 
 def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
@@ -342,7 +342,10 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "eq":
         return f"{indent}{accessor} == {literal}"
     if operator == "ne":
-        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v != {literal}"
+        # Missing paths resolve to null via the array-path accessor. Keep
+        # ``null != value`` as a match so deny-side ``ne`` fails closed when
+        # intermediate segments are omitted (#3360).
+        return f"{indent}_v := {accessor}\n{indent}_v != {literal}"
     if operator == "gt":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v > {literal}"
     if operator == "lt":
@@ -354,7 +357,9 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "in":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v in {literal}"
     if operator == "not_in":
-        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}not _v in {literal}"
+        # Same fail-closed posture as ``ne``: a missing path (null) is not a
+        # member of the allowlist, so ``not_in`` matches (#3360).
+        return f"{indent}_v := {accessor}\n{indent}not _v in {literal}"
     if operator == "exists":
         return f"{indent}{accessor} != null"
     if operator == "contains":

--- a/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
@@ -1017,3 +1017,54 @@ def test_resolution_error_message_includes_reason_string() -> None:
     err = ResolutionError.path_traversal("detail-x")
     assert "runtime_error:resolution_path_traversal" in str(err)
     assert "detail-x" in str(err)
+
+
+def test_rego_field_accessor_uses_array_path_for_nested_fields() -> None:
+    """#3360: intermediate-missing paths must still resolve to null."""
+    from agt.cli._migrate_resolution.build import _rego_field_accessor, _rego_op_clause
+
+    accessor = _rego_field_accessor("tool_call.args.region")
+    assert accessor == (
+        'object.get(input.snapshot, ["tool_call", "args", "region"], null)'
+    )
+    assert "object.get(object.get" not in (accessor or "")
+
+    ne_clause = _rego_op_clause("ne", accessor, "eu")
+    assert ne_clause is not None
+    assert "_v != null" not in ne_clause
+    assert '_v != "eu"' in ne_clause
+
+    not_in_clause = _rego_op_clause("not_in", accessor, ["eu", "us"])
+    assert not_in_clause is not None
+    assert "_v != null" not in not_in_clause
+    assert "not _v in" in not_in_clause
+
+
+def test_resolve_renders_array_path_accessor_for_nested_ne(tmp_path: Path) -> None:
+    root = tmp_path
+    _write(
+        root / "governance.yaml",
+        {
+            "rules": [
+                _rule_with_condition(
+                    "deny-missing-region",
+                    "deny",
+                    {
+                        "field": "tool_call.args.region",
+                        "operator": "ne",
+                        "value": "eu",
+                    },
+                )
+            ],
+            "intervention_points": _legacy_binding(),
+        },
+    )
+
+    manifest = resolve_manifest(root, root)
+    bundle = Path(manifest["policies"]["agt_legacy_rules"]["bundle"])
+    rego = (bundle / "agt_legacy.rego").read_text(encoding="utf-8")
+
+    assert (
+        'object.get(input.snapshot, ["tool_call", "args", "region"], null)' in rego
+    )
+    assert "object.get(object.get" not in rego

--- a/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
@@ -1048,7 +1048,7 @@ def test_rego_field_accessor_uses_array_path_for_nested_fields() -> None:
 
 @pytest.mark.parametrize(
     ("operator", "value"),
-    [("ne", "eu"), ("not_in", ["eu", "us"])],
+    [("eq", None), ("ne", "eu"), ("not_in", ["eu", "us"])],
 )
 def test_allow_operator_keeps_missing_field_guard(
     operator: str, value: object

--- a/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
@@ -9,8 +9,12 @@ resolution reasons in ``policy-engine/spec/SPECIFICATION.md`` §16.
 
 from __future__ import annotations
 
+import json
+import os
 import random
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -1029,15 +1033,101 @@ def test_rego_field_accessor_uses_array_path_for_nested_fields() -> None:
     )
     assert "object.get(object.get" not in (accessor or "")
 
-    ne_clause = _rego_op_clause("ne", accessor, "eu")
+    ne_clause = _rego_op_clause("ne", accessor, "eu", action="deny")
     assert ne_clause is not None
     assert "_v != null" not in ne_clause
     assert '_v != "eu"' in ne_clause
 
-    not_in_clause = _rego_op_clause("not_in", accessor, ["eu", "us"])
+    not_in_clause = _rego_op_clause(
+        "not_in", accessor, ["eu", "us"], action="deny"
+    )
     assert not_in_clause is not None
     assert "_v != null" not in not_in_clause
     assert "not _v in" in not_in_clause
+
+
+@pytest.mark.parametrize(
+    ("operator", "value"),
+    [("ne", "eu"), ("not_in", ["eu", "us"])],
+)
+def test_allow_operator_keeps_missing_field_guard(
+    operator: str, value: object
+) -> None:
+    from agt.cli._migrate_resolution.build import _rego_op_clause
+
+    clause = _rego_op_clause(
+        operator,
+        'object.get(input.snapshot, ["tool_call", "args", "region"], null)',
+        value,
+        action="allow",
+    )
+
+    assert clause is not None
+    assert "_v != null" in clause
+
+
+@pytest.mark.parametrize(
+    ("operator", "value"),
+    [("ne", "eu"), ("not_in", ["eu", "us"])],
+)
+def test_allow_missing_field_does_not_preempt_later_deny(
+    tmp_path: Path, operator: str, value: object
+) -> None:
+    """An allow condition cannot match when its selected field is absent."""
+    opa = os.environ.get("ACS_OPA_PATH") or shutil.which("opa")
+    if opa is None:
+        pytest.skip("OPA is required to evaluate generated Rego")
+
+    from agt.cli._migrate_resolution.build import _render_rego
+
+    rego_path = tmp_path / "agt_legacy.rego"
+    rego_path.write_text(
+        _render_rego(
+            [
+                _rule_with_condition(
+                    "allow-non-eu",
+                    "allow",
+                    {
+                        "field": "tool_call.args.region",
+                        "operator": operator,
+                        "value": value,
+                    },
+                    10,
+                ),
+                _rule_with_condition(
+                    "deny-deploy",
+                    "deny",
+                    {
+                        "field": "tool_call.name",
+                        "operator": "eq",
+                        "value": "deploy",
+                    },
+                    0,
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [
+            opa,
+            "eval",
+            "--format=raw",
+            "--data",
+            str(rego_path),
+            "--stdin-input",
+            "data.agt.legacy.verdict",
+        ],
+        input=json.dumps({"snapshot": {"tool_call": {"name": "deploy"}}}),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    verdict = json.loads(result.stdout)
+    assert verdict["decision"] == "deny"
+    assert verdict["reason"] == "deny-deploy"
 
 
 def test_resolve_renders_array_path_accessor_for_nested_ne(tmp_path: Path) -> None:

--- a/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
@@ -1068,7 +1068,7 @@ def test_allow_operator_keeps_missing_field_guard(
 
 @pytest.mark.parametrize(
     ("operator", "value"),
-    [("ne", "eu"), ("not_in", ["eu", "us"])],
+    [("eq", None), ("ne", "eu"), ("not_in", ["eu", "us"])],
 )
 def test_allow_missing_field_does_not_preempt_later_deny(
     tmp_path: Path, operator: str, value: object

--- a/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
@@ -1158,3 +1158,36 @@ def test_resolve_renders_array_path_accessor_for_nested_ne(tmp_path: Path) -> No
         'object.get(input.snapshot, ["tool_call", "args", "region"], null)' in rego
     )
     assert "object.get(object.get" not in rego
+
+
+@pytest.mark.parametrize(
+    ("operator", "value"),
+    [
+        ("eq", "us-east-1"),
+        ("ne", "eu-west-1"),
+        ("in", ["us-east-1", "us-west-2"]),
+        ("not_in", ["eu-west-1"]),
+        ("contains", "us"),
+        ("startswith", "us"),
+        ("endswith", "1"),
+        ("matches", "us-.*"),
+    ],
+)
+def test_allow_missing_field_never_matches(operator: str, value: object) -> None:
+    """An allow condition must not fire when the referenced field is absent.
+
+    Requested by reviewer: covers the allow + missing-field case for every
+    scalar operator, asserting the allow does NOT fire — complementing the
+    existing deny-flavored Rego shape tests.
+    """
+    sample_with_field = {"tool_call": {"args": {"region": "us-east-1"}}}
+    sample_without_field = {"tool_call": {"args": {}}}
+
+    cond = {"field": "tool_call.args.region", "operator": operator, "value": value}
+
+    assert _condition_matches(cond, sample_with_field), (
+        f"sanity: {operator} should match when field is present"
+    )
+    assert not _condition_matches(cond, sample_without_field), (
+        f"{operator}: allow must not fire when the field is absent"
+    )


### PR DESCRIPTION
## Summary
- Deny `ne` / `not_in` rules still failed open when an intermediate snapshot path segment was missing, because chained `object.get` returned undefined instead of null.
- Generate array-path `object.get(input.snapshot, [...], null)` accessors and keep negative operators matching on null so those denies fail closed.

Fixes #3360

## Test plan
- [x] Hermetic assertions on `_rego_field_accessor` / `_rego_op_clause`
- [x] Added unit coverage in `tests/test_migrate_resolution.py`