### PR TITLE
fix(agent-os): make supervisor hierarchy gap scan O(n)

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/supervisor.py
+++ b/agent-governance-python/agent-os/src/agent_os/supervisor.py
@@ -92,12 +92,32 @@ class SupervisorHierarchy:
                         f"Level 0 supervisor '{s.name}' must be deterministic, not an LLM agent"
                     )
 
-        # Ensure no gaps in levels (every level between 0 and max has a supervisor)
-        if self._supervisors:
-            max_level = max(s.level for s in self._supervisors)
-            for lvl in range(1, max_level + 1):
-                if not any(s.level == lvl for s in self._supervisors):
-                    violations.append(f"Level {lvl} has no registered supervisor")
+        # Ensure no gaps in levels (every level between 0 and max has a supervisor).
+        # Derive gaps from the sorted set of registered non-negative levels rather
+        # than ``range(1, max_level + 1)``. A pathological level such as
+        # ``10**100`` would otherwise hang validation forever (#3788).
+        non_negative = sorted({s.level for s in self._supervisors if s.level >= 0})
+        if non_negative:
+            chain: list[int] = []
+            for lvl in (0, *non_negative):
+                if not chain or chain[-1] != lvl:
+                    chain.append(lvl)
+            # Enumerate individual missing levels for small gaps so existing
+            # callers keep seeing ``Level N has no registered supervisor``.
+            # Collapse huge gaps into one summary message.
+            max_enumerated_gap = 64
+            for prev, curr in zip(chain, chain[1:]):
+                missing = curr - prev - 1
+                if missing <= 0:
+                    continue
+                if missing <= max_enumerated_gap:
+                    for lvl in range(prev + 1, curr):
+                        violations.append(f"Level {lvl} has no registered supervisor")
+                else:
+                    violations.append(
+                        f"Levels {prev + 1} through {curr - 1} have no registered "
+                        f"supervisor ({missing} missing levels)"
+                    )
 
         return violations
 

--- a/agent-governance-python/agent-os/tests/test_trust_root.py
+++ b/agent-governance-python/agent-os/tests/test_trust_root.py
@@ -104,8 +104,27 @@ def test_negative_level_outranks_the_root_in_the_authority_chain() -> None:
 
 @pytest.mark.parametrize('level', [-1, -7])
 def test_negative_level_is_reported_even_without_a_level_0(level: int) -> None:
-    # The gap scan walks range(1, max_level + 1), which is empty when the highest
-    # level is negative, so nothing else would fire here either.
+    # Negative-only hierarchies never enter the non-negative gap scan.
     hierarchy = SupervisorHierarchy(trust_root=_root())
     hierarchy.register_supervisor('only', level=level, is_agent=True)
     assert any('negative level' in v for v in hierarchy.validate_hierarchy())
+
+
+def test_hierarchy_gap_scan_reports_missing_middle_levels() -> None:
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('trust-root', level=0, is_agent=False)
+    hierarchy.register_supervisor('worker', level=3, is_agent=True)
+    violations = hierarchy.validate_hierarchy()
+    assert 'Level 1 has no registered supervisor' in violations
+    assert 'Level 2 has no registered supervisor' in violations
+
+
+def test_pathological_supervisor_level_does_not_hang_validation() -> None:
+    """``range(1, max_level + 1)`` hung forever for huge integer levels (#3788)."""
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('trust-root', level=0, is_agent=False)
+    hierarchy.register_supervisor('far-away', level=10**100, is_agent=True)
+    violations = hierarchy.validate_hierarchy()
+    assert violations
+    assert any('missing levels' in v for v in violations)
+    assert not any(v.startswith('Level 1 has no') for v in violations)


### PR DESCRIPTION
## Summary
- `SupervisorHierarchy.validate_hierarchy()` no longer walks `range(1, max_level + 1)`.
- Gaps are derived from the sorted set of registered non-negative levels (O(n log n)).
- Small gaps still emit per-level `Level N has no registered supervisor` messages; huge gaps collapse to one summary so a pathological level like `10**100` cannot hang validation.

Fixes #3788

## Test plan
- [x] Added `test_hierarchy_gap_scan_reports_missing_middle_levels`
- [x] Added `test_pathological_supervisor_level_does_not_hang_validation` (`level=10**100` finishes immediately)
- [x] Hermetic import of `supervisor.py` confirmed small-gap messages and sub-millisecond pathological validation
