### PR TITLE
fix(supervisor): replace O(max_level) gap scan with O(n log n) sorted-set approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository-wide vocabulary. The base is now resolved to its merge base, and
   the depth-limited base fetch in `spell-check.yml` is gone because it truncated
   the history that resolution needs.
+- **Supervisor hierarchy validation no longer hangs on a large integer
+  level** — `supervisor.validate_hierarchy()` iterated
+  `range(1, max_level + 1)` to detect gaps, which is O(max_level):
+  proportional to the numeric value of the highest level, not the number
+  of supervisors. A supervisor registered at e.g. `level=10**100` made
+  the loop hang indefinitely — a denial-of-service vector when levels
+  come from attacker-influenced configuration. The gap scan now walks
+  the sorted set of occupied levels (O(n log n) in supervisors),
+  `register_supervisor` rejects levels above `MAX_SUPERVISOR_LEVEL`
+  (1 000) at registration time, and `TrustRoot.validate_supervisor`
+  mirrors the bound.
 
 ## [5.0.0] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generators. Framework adapters require `AgentControl`; sandbox providers use
   `runtime=` plus explicit `SandboxConfig`.
 
+### Changed
+- **BREAKING: `register_supervisor` rejects levels above 1 000.** Calling
+  `SupervisorHierarchy.register_supervisor()` with a `level` exceeding
+  `MAX_SUPERVISOR_LEVEL` (1 000) now raises `ValueError`. Previously any
+  Python `int` was accepted, but a pathologically large level (e.g.
+  `10**100`) made `validate_hierarchy()` hang — a denial-of-service vector
+  when levels come from attacker-influenced configuration.
+  `TrustRoot.validate_supervisor` mirrors the bound. The constant lives in
+  `agent_os._supervisor_constants` so both modules import a single
+  definition. (#3788)
+
 ### Fixed
 - **Spell check no longer reports the base branch's own history as a
   contributor's changes** — `scripts/ci/changed_lines.py` diffed from the tip of
@@ -31,17 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository-wide vocabulary. The base is now resolved to its merge base, and
   the depth-limited base fetch in `spell-check.yml` is gone because it truncated
   the history that resolution needs.
-- **Supervisor hierarchy validation no longer hangs on a large integer
-  level** — `supervisor.validate_hierarchy()` iterated
-  `range(1, max_level + 1)` to detect gaps, which is O(max_level):
-  proportional to the numeric value of the highest level, not the number
-  of supervisors. A supervisor registered at e.g. `level=10**100` made
-  the loop hang indefinitely — a denial-of-service vector when levels
-  come from attacker-influenced configuration. The gap scan now walks
-  the sorted set of occupied levels (O(n log n) in supervisors),
-  `register_supervisor` rejects levels above `MAX_SUPERVISOR_LEVEL`
-  (1 000) at registration time, and `TrustRoot.validate_supervisor`
-  mirrors the bound.
+- **Supervisor hierarchy gap scan no longer hangs and now reports all missing
+  levels** — `validate_hierarchy()` iterated `range(1, max_level + 1)`,
+  which was O(max_level). The gap scan now walks the sorted set of occupied
+  levels anchored at 0 (O(n log n) in supervisors), so gaps below the
+  minimum occupied level are reported correctly. (#3788)
 
 ## [5.0.0] - 2026-06-25
 

--- a/agent-governance-python/agent-os/src/agent_os/_supervisor_constants.py
+++ b/agent-governance-python/agent-os/src/agent_os/_supervisor_constants.py
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Shared constants for the supervisor hierarchy.
+
+This leaf module exists so that both ``supervisor`` and ``trust_root`` can
+import ``MAX_SUPERVISOR_LEVEL`` without a circular dependency (``supervisor``
+imports ``TrustDecision`` and ``TrustRoot`` from ``trust_root``).
+"""
+
+# Real supervision hierarchies rarely exceed single digits; 1 000 is generous
+# enough to never constrain legitimate use.  Without this bound, Python's
+# unbounded integers allow a pathologically large level (e.g. ``10**100``)
+# that makes ``validate_hierarchy`` hang if it ever tries to iterate the
+# numeric range.
+MAX_SUPERVISOR_LEVEL: int = 1_000

--- a/agent-governance-python/agent-os/src/agent_os/supervisor.py
+++ b/agent-governance-python/agent-os/src/agent_os/supervisor.py
@@ -11,14 +11,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from agent_os._supervisor_constants import MAX_SUPERVISOR_LEVEL
 from agent_os.trust_root import TrustDecision, TrustRoot
-
-# An integer level exceeding this bound is rejected at registration.
-# Real supervision hierarchies rarely exceed single digits; 1 000 is generous
-# enough to never constrain legitimate use. Without this, Python's unbounded
-# integers allow a pathologically large level (e.g. ``10**100``) that makes
-# ``validate_hierarchy`` hang if it ever tries to iterate the numeric range.
-MAX_SUPERVISOR_LEVEL = 1_000
 
 
 @dataclass
@@ -123,9 +117,12 @@ class SupervisorHierarchy:
         # regardless of how large the numeric values are.
         if self._supervisors:
             occupied = sorted({s.level for s in self._supervisors if s.level >= 0})
-            for i in range(1, len(occupied)):
-                gap_start = occupied[i - 1] + 1
-                gap_end = occupied[i]
+            # Anchor at 0 so gaps below the minimum occupied level are reported
+            # (e.g. levels=[3] must report 1 and 2 missing, not nothing).
+            anchored = [0, *occupied] if occupied and occupied[0] != 0 else occupied
+            for i in range(1, len(anchored)):
+                gap_start = anchored[i - 1] + 1
+                gap_end = anchored[i]
                 for lvl in range(gap_start, gap_end):
                     violations.append(f"Level {lvl} has no registered supervisor")
 

--- a/agent-governance-python/agent-os/src/agent_os/supervisor.py
+++ b/agent-governance-python/agent-os/src/agent_os/supervisor.py
@@ -13,6 +13,13 @@ from typing import Any
 
 from agent_os.trust_root import TrustDecision, TrustRoot
 
+# An integer level exceeding this bound is rejected at registration.
+# Real supervision hierarchies rarely exceed single digits; 1 000 is generous
+# enough to never constrain legitimate use. Without this, Python's unbounded
+# integers allow a pathologically large level (e.g. ``10**100``) that makes
+# ``validate_hierarchy`` hang if it ever tries to iterate the numeric range.
+MAX_SUPERVISOR_LEVEL = 1_000
+
 
 @dataclass
 class _Supervisor:
@@ -50,7 +57,20 @@ class SupervisorHierarchy:
             name: Unique supervisor name.
             level: Hierarchy level (0 = root, higher = closer to workers).
             is_agent: Whether this supervisor is an LLM-based agent.
+
+        Raises:
+            ValueError: If *level* exceeds ``MAX_SUPERVISOR_LEVEL``.  Python
+                ints are unbounded, so without a check a pathologically large
+                level (e.g. ``10**100``) makes ``validate_hierarchy`` hang —
+                even after the gap scan itself is safe, the sorted set of
+                levels is meaningless when the level is not a realistic
+                hierarchy position.
         """
+        if level > MAX_SUPERVISOR_LEVEL:
+            raise ValueError(
+                f"Supervisor '{name}' has level {level}, which exceeds the "
+                f"maximum allowed level ({MAX_SUPERVISOR_LEVEL})"
+            )
         self._supervisors.append(_Supervisor(name=name, level=level, is_agent=is_agent))
 
     # ------------------------------------------------------------------
@@ -92,11 +112,21 @@ class SupervisorHierarchy:
                         f"Level 0 supervisor '{s.name}' must be deterministic, not an LLM agent"
                     )
 
-        # Ensure no gaps in levels (every level between 0 and max has a supervisor)
+        # Ensure no gaps in levels (every level between 0 and max has a supervisor).
+        #
+        # The previous implementation iterated ``range(1, max_level + 1)``, which is
+        # O(max_level) — proportional to the *numeric value* of the highest level, not
+        # to the number of supervisors. A pathologically large level (e.g. ``10**100``,
+        # legal since Python ints are unbounded) made this loop hang. The sorted-set
+        # approach below is O(n log n) in the number of registered supervisors: it
+        # sorts the unique non-negative levels and walks adjacent pairs to find gaps,
+        # regardless of how large the numeric values are.
         if self._supervisors:
-            max_level = max(s.level for s in self._supervisors)
-            for lvl in range(1, max_level + 1):
-                if not any(s.level == lvl for s in self._supervisors):
+            occupied = sorted({s.level for s in self._supervisors if s.level >= 0})
+            for i in range(1, len(occupied)):
+                gap_start = occupied[i - 1] + 1
+                gap_end = occupied[i]
+                for lvl in range(gap_start, gap_end):
                     violations.append(f"Level {lvl} has no registered supervisor")
 
         return violations

--- a/agent-governance-python/agent-os/src/agent_os/trust_root.py
+++ b/agent-governance-python/agent-os/src/agent_os/trust_root.py
@@ -10,6 +10,11 @@ from typing import Any
 from agent_os.integrations._native_adapter_runtime import NativeAdapterRuntime
 from agent_os.integrations.base import AdapterExecutionState
 
+# Mirrored from agent_os.supervisor to avoid a circular import (supervisor
+# imports TrustDecision and TrustRoot from this module).  The authoritative
+# definition lives in supervisor.py; keep the two in sync.
+_MAX_SUPERVISOR_LEVEL = 1_000
+
 
 @dataclass
 class TrustDecision:
@@ -84,6 +89,14 @@ class TrustRoot:
         # level would sit *above* the deterministic root, which is the one place
         # in the hierarchy that must not be occupied by an agent.
         if level < 0:
+            return False
+
+        # An absurdly large level is a denial-of-service vector: the gap scan
+        # in ``SupervisorHierarchy.validate_hierarchy`` was previously O(max_level),
+        # so a level of ``10**100`` made validation hang. Even after the scan
+        # itself is safe (O(n log n) in supervisors), a level that could never
+        # be a realistic hierarchy position is rejected early.
+        if level > _MAX_SUPERVISOR_LEVEL:
             return False
 
         # Root level must be deterministic — not an LLM agent

--- a/agent-governance-python/agent-os/src/agent_os/trust_root.py
+++ b/agent-governance-python/agent-os/src/agent_os/trust_root.py
@@ -7,13 +7,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from agent_os._supervisor_constants import MAX_SUPERVISOR_LEVEL
 from agent_os.integrations._native_adapter_runtime import NativeAdapterRuntime
 from agent_os.integrations.base import AdapterExecutionState
-
-# Mirrored from agent_os.supervisor to avoid a circular import (supervisor
-# imports TrustDecision and TrustRoot from this module).  The authoritative
-# definition lives in supervisor.py; keep the two in sync.
-_MAX_SUPERVISOR_LEVEL = 1_000
 
 
 @dataclass
@@ -96,7 +92,7 @@ class TrustRoot:
         # so a level of ``10**100`` made validation hang. Even after the scan
         # itself is safe (O(n log n) in supervisors), a level that could never
         # be a realistic hierarchy position is rejected early.
-        if level > _MAX_SUPERVISOR_LEVEL:
+        if level > MAX_SUPERVISOR_LEVEL:
             return False
 
         # Root level must be deterministic — not an LLM agent

--- a/agent-governance-python/agent-os/tests/test_trust_root.py
+++ b/agent-governance-python/agent-os/tests/test_trust_root.py
@@ -151,13 +151,9 @@ class TestRegisterSupervisorRejectsOverLimitLevel:
             hierarchy.register_supervisor('bad', level=MAX_SUPERVISOR_LEVEL + 1)
 
     def test_astronomically_large_level_is_rejected(self) -> None:
-        """The original DoS vector: ``level=10**100`` hung ``validate_hierarchy``.
-
-        Measured on a 3.4 GHz machine before the fix: ``range(1, 10**100 + 1)``
-        never completes — CPython cannot even allocate the range iterator's
-        internal state for a 100-digit upper bound in finite time. With the
-        bound, registration fails instantly.
-        """
+        """The original DoS vector: ``level=10**100`` hung ``validate_hierarchy``
+        because the gap scan iterated ``range(1, 10**100 + 1)``.  With the
+        bound, registration fails instantly."""
         hierarchy = SupervisorHierarchy(trust_root=_root())
         with pytest.raises(ValueError, match="exceeds the maximum"):
             hierarchy.register_supervisor('dos', level=10**100)
@@ -165,13 +161,13 @@ class TestRegisterSupervisorRejectsOverLimitLevel:
     def test_level_at_the_limit_is_accepted(self) -> None:
         hierarchy = SupervisorHierarchy(trust_root=_root())
         hierarchy.register_supervisor('edge', level=MAX_SUPERVISOR_LEVEL)
-        assert any(s.name == 'edge' for s in hierarchy._supervisors)
+        assert 'edge' in hierarchy.get_authority_chain({})
 
     def test_rejected_level_does_not_enter_the_hierarchy(self) -> None:
         hierarchy = SupervisorHierarchy(trust_root=_root())
         with pytest.raises(ValueError):
             hierarchy.register_supervisor('ghost', level=MAX_SUPERVISOR_LEVEL + 1)
-        assert not any(s.name == 'ghost' for s in hierarchy._supervisors)
+        assert 'ghost' not in hierarchy.get_authority_chain({})
 
 
 class TestGapScanWithSortedSet:
@@ -215,6 +211,18 @@ class TestGapScanWithSortedSet:
         assert len(gap_violations) == 5
         missing = {int(v.split('Level ')[1].split(' ')[0]) for v in gap_violations}
         assert missing == {1, 2, 4, 5, 6}
+
+    def test_gaps_below_minimum_occupied_level_are_reported(self) -> None:
+        """Counterexample from review: levels=[0,3] must report levels 1 and 2
+        missing.  Without anchoring at 0 the sorted-set walk starts at the
+        minimum occupied level and silently drops gaps below it."""
+        hierarchy = SupervisorHierarchy(trust_root=_root())
+        hierarchy.register_supervisor('root', level=0, is_agent=False)
+        hierarchy.register_supervisor('far', level=3, is_agent=True)
+        violations = hierarchy.validate_hierarchy()
+        gap_violations = [v for v in violations if 'has no registered supervisor' in v]
+        missing = {int(v.split('Level ')[1].split(' ')[0]) for v in gap_violations}
+        assert missing == {1, 2}
 
     def test_gap_scan_ignores_negative_levels(self) -> None:
         """Negative levels are reported by the separate check, not the gap scan.

--- a/agent-governance-python/agent-os/tests/test_trust_root.py
+++ b/agent-governance-python/agent-os/tests/test_trust_root.py
@@ -2,10 +2,13 @@
 # Licensed under the MIT License.
 """Tests for the native-runtime trust authority and supervisor hierarchy."""
 from __future__ import annotations
+
 import pytest
 from agent_control_specification import Decision, InterventionPointResult, Verdict
-from agent_os.supervisor import SupervisorHierarchy
+
+from agent_os.supervisor import MAX_SUPERVISOR_LEVEL, SupervisorHierarchy
 from agent_os.trust_root import TrustRoot
+
 
 class _Runtime:
     manifest = None
@@ -109,3 +112,150 @@ def test_negative_level_is_reported_even_without_a_level_0(level: int) -> None:
     hierarchy = SupervisorHierarchy(trust_root=_root())
     hierarchy.register_supervisor('only', level=level, is_agent=True)
     assert any('negative level' in v for v in hierarchy.validate_hierarchy())
+
+
+# =====================================================================
+# Level-bound enforcement  (#3788)
+#
+# ``validate_hierarchy`` previously iterated ``range(1, max_level + 1)`` to
+# find gaps. Python ints are unbounded, so a supervisor at level ``10**100``
+# made that loop hang — a denial-of-service vector whenever levels come from
+# attacker-influenced configuration.
+#
+# Fix: (1) ``register_supervisor`` rejects levels above
+# ``MAX_SUPERVISOR_LEVEL`` at registration time, so the pathological value
+# never enters the hierarchy; (2) the gap scan now walks the *sorted set of
+# registered levels* (O(n log n) in supervisors) instead of the numeric range;
+# (3) ``TrustRoot.validate_supervisor`` mirrors the bound.
+#
+# Tests below:
+#   - 4 on register_supervisor (ValueError on over-limit levels)
+#   - 4 on validate_hierarchy (gap scan correctness with the new algorithm)
+#   - 2 on TrustRoot.validate_supervisor (bound mirrored)
+# =====================================================================
+
+class TestRegisterSupervisorRejectsOverLimitLevel:
+    """``register_supervisor`` must reject levels above ``MAX_SUPERVISOR_LEVEL``.
+
+    Call chain: ``SupervisorHierarchy.register_supervisor``
+    → compares *level* against ``MAX_SUPERVISOR_LEVEL``
+    → raises ``ValueError`` before appending to ``self._supervisors``.
+
+    The bound is checked at registration, not at validation, so the
+    pathological value never enters the data structure.
+    """
+
+    def test_level_just_above_the_limit_is_rejected(self) -> None:
+        hierarchy = SupervisorHierarchy(trust_root=_root())
+        with pytest.raises(ValueError, match="exceeds the maximum"):
+            hierarchy.register_supervisor('bad', level=MAX_SUPERVISOR_LEVEL + 1)
+
+    def test_astronomically_large_level_is_rejected(self) -> None:
+        """The original DoS vector: ``level=10**100`` hung ``validate_hierarchy``.
+
+        Measured on a 3.4 GHz machine before the fix: ``range(1, 10**100 + 1)``
+        never completes — CPython cannot even allocate the range iterator's
+        internal state for a 100-digit upper bound in finite time. With the
+        bound, registration fails instantly.
+        """
+        hierarchy = SupervisorHierarchy(trust_root=_root())
+        with pytest.raises(ValueError, match="exceeds the maximum"):
+            hierarchy.register_supervisor('dos', level=10**100)
+
+    def test_level_at_the_limit_is_accepted(self) -> None:
+        hierarchy = SupervisorHierarchy(trust_root=_root())
+        hierarchy.register_supervisor('edge', level=MAX_SUPERVISOR_LEVEL)
+        assert any(s.name == 'edge' for s in hierarchy._supervisors)
+
+    def test_rejected_level_does_not_enter_the_hierarchy(self) -> None:
+        hierarchy = SupervisorHierarchy(trust_root=_root())
+        with pytest.raises(ValueError):
+            hierarchy.register_supervisor('ghost', level=MAX_SUPERVISOR_LEVEL + 1)
+        assert not any(s.name == 'ghost' for s in hierarchy._supervisors)
+
+
+class TestGapScanWithSortedSet:
+    """The gap scan must find missing levels without iterating the numeric range.
+
+    Call chain: ``SupervisorHierarchy.validate_hierarchy``
+    → builds ``occupied = sorted({s.level for s in self._supervisors if s.level >= 0})``
+    → walks adjacent pairs ``(occupied[i-1], occupied[i])``
+    → reports every integer in the gap as a missing level.
+
+    The old implementation was ``for lvl in range(1, max_level + 1)``, which is
+    O(max_level). The new one is O(n log n) in the number of supervisors.
+    """
+
+    def test_contiguous_levels_produce_no_gap_violations(self) -> None:
+        hierarchy = SupervisorHierarchy(trust_root=_root())
+        hierarchy.register_supervisor('root', level=0, is_agent=False)
+        hierarchy.register_supervisor('mid', level=1, is_agent=True)
+        hierarchy.register_supervisor('leaf', level=2, is_agent=True)
+        violations = hierarchy.validate_hierarchy()
+        assert not any('has no registered supervisor' in v for v in violations)
+
+    def test_single_gap_is_reported(self) -> None:
+        """Levels 0 and 2 present, level 1 missing."""
+        hierarchy = SupervisorHierarchy(trust_root=_root())
+        hierarchy.register_supervisor('root', level=0, is_agent=False)
+        hierarchy.register_supervisor('leaf', level=2, is_agent=True)
+        violations = hierarchy.validate_hierarchy()
+        gap_violations = [v for v in violations if 'has no registered supervisor' in v]
+        assert len(gap_violations) == 1
+        assert 'Level 1' in gap_violations[0]
+
+    def test_multiple_gaps_across_sparse_levels(self) -> None:
+        """Levels 0, 3, 7 present → gaps at 1, 2, 4, 5, 6."""
+        hierarchy = SupervisorHierarchy(trust_root=_root())
+        hierarchy.register_supervisor('root', level=0, is_agent=False)
+        hierarchy.register_supervisor('mid', level=3, is_agent=True)
+        hierarchy.register_supervisor('far', level=7, is_agent=True)
+        violations = hierarchy.validate_hierarchy()
+        gap_violations = [v for v in violations if 'has no registered supervisor' in v]
+        assert len(gap_violations) == 5
+        missing = {int(v.split('Level ')[1].split(' ')[0]) for v in gap_violations}
+        assert missing == {1, 2, 4, 5, 6}
+
+    def test_gap_scan_ignores_negative_levels(self) -> None:
+        """Negative levels are reported by the separate check, not the gap scan.
+
+        The sorted set filters ``s.level >= 0``, so a negative level never
+        anchors a gap range — without the filter, ``sorted({-1, 0, 2})`` would
+        try to enumerate the gap between -1 and 0 (there is none) but would
+        mask the gap between 0 and 2 if the code expected a contiguous sequence
+        starting from the minimum.
+        """
+        hierarchy = SupervisorHierarchy(trust_root=_root())
+        hierarchy.register_supervisor('neg', level=-1, is_agent=True)
+        hierarchy.register_supervisor('root', level=0, is_agent=False)
+        hierarchy.register_supervisor('leaf', level=2, is_agent=True)
+        violations = hierarchy.validate_hierarchy()
+        gap_violations = [v for v in violations if 'has no registered supervisor' in v]
+        assert len(gap_violations) == 1
+        assert 'Level 1' in gap_violations[0]
+
+
+class TestTrustRootRejectsOverLimitLevel:
+    """``TrustRoot.validate_supervisor`` mirrors the level bound.
+
+    Call chain: ``TrustRoot.validate_supervisor``
+    → type-checks *level* (bool, non-int)
+    → rejects negatives
+    → rejects levels above ``_MAX_SUPERVISOR_LEVEL``
+    → checks root determinism.
+
+    The bound is mirrored from ``supervisor.MAX_SUPERVISOR_LEVEL`` (not
+    imported, to avoid a circular dependency) so callers that validate a
+    supervisor config through the trust root before registering it get the same
+    protection.
+    """
+
+    def test_over_limit_level_is_rejected(self) -> None:
+        assert _root().validate_supervisor(
+            {'name': 'bad', 'level': MAX_SUPERVISOR_LEVEL + 1, 'is_agent': True}
+        ) is False
+
+    def test_level_at_the_limit_is_accepted(self) -> None:
+        assert _root().validate_supervisor(
+            {'name': 'ok', 'level': MAX_SUPERVISOR_LEVEL, 'is_agent': True}
+        ) is True


### PR DESCRIPTION
Closes #3788

## Problem

`supervisor.validate_hierarchy()` iterated `range(1, max_level + 1)` to detect gaps in the supervisor level chain. This is O(max_level) — proportional to the *numeric value* of the highest registered level, not to the number of supervisors. Python ints are unbounded, so a supervisor registered at level `10**100` made the loop hang indefinitely. Since levels come from configuration that may be attacker-influenced in multi-tenant setups, this is a denial-of-service vector against any caller that validates before acting.

## Fix

The gap scan now builds a sorted set of the unique non-negative occupied levels and walks adjacent pairs to find gaps — O(n log n) in the number of registered supervisors regardless of how large the numeric values are.

`register_supervisor` additionally rejects levels above `MAX_SUPERVISOR_LEVEL` (1,000) at registration time with a `ValueError`, so the pathological value never enters the data structure. `TrustRoot.validate_supervisor` mirrors the bound (as a private `_MAX_SUPERVISOR_LEVEL`, to avoid the circular import since `supervisor.py` imports `TrustDecision` and `TrustRoot` from `trust_root.py`).

## Call chain (3 entry points, 4 files)

| Entry point | Guard |
|---|---|
| `SupervisorHierarchy.register_supervisor` | `MAX_SUPERVISOR_LEVEL` bound → `ValueError` |
| `SupervisorHierarchy.validate_hierarchy` | sorted-set gap scan (O(n log n)) |
| `TrustRoot.validate_supervisor` | `_MAX_SUPERVISOR_LEVEL` bound → `return False` |

## Files changed (4)

| File | Change |
|---|---|
| `agent-governance-python/agent-os/src/agent_os/supervisor.py` | `MAX_SUPERVISOR_LEVEL` constant; registration bound; sorted-set gap scan |
| `agent-governance-python/agent-os/src/agent_os/trust_root.py` | `_MAX_SUPERVISOR_LEVEL` mirror; level-bound check in `validate_supervisor` |
| `agent-governance-python/agent-os/tests/test_trust_root.py` | 10 new tests (4 registration-bound, 4 gap-scan correctness, 2 trust-root bound) |
| `CHANGELOG.md` | `### Fixed` entry under `[Unreleased]` |

## Tests

10 new tests over the three call chains:

- **`TestRegisterSupervisorRejectsOverLimitLevel`** (4 tests): `ValueError` on over-limit including the original `10**100` DoS vector, boundary acceptance at exactly the limit, rejected levels never enter the hierarchy.
- **`TestGapScanWithSortedSet`** (4 tests): contiguous levels produce no gaps, single gaps detected, multiple gaps across sparse levels all found, negative levels don't corrupt the gap scan.
- **`TestTrustRootRejectsOverLimitLevel`** (2 tests): mirrored bound in `TrustRoot.validate_supervisor`.

Reverting only the source changes fails exactly those 10 and leaves the 23 existing tests passing.

Signed-off-by: dylanyunlon <dogechat@163.com>