### PR TITLE
docs: add PALO external accountability reference implementation

### DIFF
--- a/docs/integrations/external-operation-accountability-profiles.md
+++ b/docs/integrations/external-operation-accountability-profiles.md
@@ -1,8 +1,10 @@
 ---
 title: "External Operation-Accountability Profiles"
-last_reviewed: 2026-04-26
+last_reviewed: 2026-08-23
 owner: agt-maintainers
 ---
+
+<!-- cspell:words PALO -->
 
 <!-- Copyright (c) Microsoft Corporation. Licensed under the MIT License. -->
 
@@ -114,9 +116,18 @@ It is not part of the AGT runtime path.
 
 ## Example Reference Implementation
 
+- [PALO outcome-assurance interoperability with AGT ACS](https://github.com/sev7enITA/PALOframework/tree/2d6c91d6629ef1805b007af819a4dd94ca6644a7/examples/agentic-interface/integrations/microsoft-agt)
+  is a PALO-maintained, version-pinned community example that maps a
+  digest-bound PALO Action Claim to an ACS `pre_tool_call` evaluation and
+  correlates the returned verdict and evidence reference with a downstream
+  execution receipt and independent post-state verification. The adapter
+  remains outside the AGT runtime trust boundary and does not replace AGT
+  evidence verification. See
+  [Discussion #3647](https://github.com/microsoft/agent-governance-toolkit/discussions/3647).
 - Related issue: https://github.com/microsoft/agent-governance-toolkit/issues/1314
 
-No reference implementation is currently available. Community contributions welcome.
+This reference implementation is not maintained, certified, sponsored, or
+endorsed by Microsoft.
 
 ## Review Note
 


### PR DESCRIPTION
## Summary

This documentation-only change adds the PALO outcome-assurance adapter as a
community reference implementation of AGT's existing external
operation-accountability pattern.

The change adds no PALO dependency to AGT, changes no AGT runtime or public
API, does not replace AGT evidence verification, and does not imply Microsoft
maintenance, certification, sponsorship, or endorsement.

## Why this pattern is worth evaluating

AGT ACS answers whether a proposed tool call may proceed under runtime policy.
After execution crosses into the target system, that verdict is not by itself
proof that the approved business effect occurred on the intended resource.

This contribution asks one bounded technical question: should the existing
external operation-accountability guidance point to a concrete community
example that correlates an ACS decision with a separately controlled execution
receipt and an independent read of authoritative post-state?

## Residual risk when assurance stops at the pre-action verdict

A deployment that treats an `allow` verdict as proof of outcome may be unable
to distinguish among:

- the approved arguments and resource being executed exactly as reviewed;
- arguments being transformed or mutated after digest-bound approval;
- stale-state or time-of-check/time-of-use drift;
- a partial effect, wrong-resource effect, duplicate, or replayed execution;
- a tool response reporting success while authoritative business state differs;
- a policy-compliant decision followed by an inconclusive or incorrect result.

The resulting audit record can prove that a policy decision occurred without
proving request-execution-outcome equivalence. That can delay detection,
incident containment, compensation, and accountable review of an unintended
effect.

This is not a claim that AGT should own downstream business-state verification.
It is the reason to evaluate a clearly separated external accountability layer.

## What the PALO example demonstrates

- a digest-bound PALO Action Claim and Effect Contract are mapped to ACS
  `pre_tool_call`;
- AGT remains authoritative for ACS evaluation and AGT evidence integrity;
- `deny` and runtime failures fail closed, while `escalate` enters a
  digest-bound approval path;
- an ACS `transform` verdict requires a new Action Claim instead of mutating
  arguments behind an approved digest;
- an allowed claim receives a scoped one-time execution capability;
- execution produces a receipt correlated with the original claim and AGT
  evidence reference;
- an independent verifier reads authoritative post-state and classifies the
  outcome as `verified`, `mismatch`, or `inconclusive`;
- a mismatch can open an assurance incident and hold the affected resource.

The runnable synthetic demonstration covers both `allowed -> verified` and
`allowed -> mismatch -> incident hold`.

## Version and trust boundary

- PALO snapshot: `2d6c91d6629ef1805b007af819a4dd94ca6644a7`
  (`v3.0.1`, developer preview)
- AGT ACS Node SDK: `agent-control-specification@0.3.1-beta.0`
- AGT upstream pin used by the example:
  `81955d48025c6b11deb3fc9dabf89f74f4145775`
- Adapter ownership: PALO-maintained and external to the AGT runtime trust
  boundary
- License: MIT

PALO v3.0.1 also adds a digest-aware semantic and evidence foundation plus a
local Evidence Pack activation route. These supporting PALO capabilities do
not change AGT behavior or expand the scope of this pull request.

## Validation

- `python3 scripts/docs/check_links.py`
- `python3 scripts/docs/check_frontmatter.py --strict`
- `cspell` on the changed document
- `git diff --check`

The linked PALO contract suite covers allow, deny, warn, escalate, transform,
missing-package, manifest-error, runtime-error, and unknown-decision behavior.

## Related material

- Discussion: https://github.com/microsoft/agent-governance-toolkit/discussions/3647
- Version-pinned implementation:
  https://github.com/sev7enITA/PALOframework/tree/2d6c91d6629ef1805b007af819a4dd94ca6644a7/examples/agentic-interface/integrations/microsoft-agt
- Public evaluation overview:
  https://paloframework.org/docs/community/palo-microsoft-agt-interoperability-proposal.html
 