### PR TITLE
fix: paginate credential_audit search to stop silently dropping results past page 1

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/credential_audit.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/credential_audit.py
@@ -145,9 +145,29 @@ def _api(path: str, params: dict[str, str] | None = None) -> Any:
     return None
 
 
+# GitHub's search endpoints cap results at 1000 total (the "Search API"
+# result-window limit, documented at
+# https://docs.github.com/en/rest/search#about-search). A single request
+# only ever returns one page of up to `per_page` items, so a subject with
+# more issues/PRs than fit on the first page silently loses coverage on
+# exactly the pages most likely to contain the later, farther-out citations
+# a real credential spray would produce. Page through the full result
+# window instead of trusting the first response alone.
+_SEARCH_RESULT_WINDOW = 1000
+
+
 def _search(endpoint: str, query: str, per_page: int = 100) -> list[dict]:
-    data = _api(f"/search/{endpoint}", {"q": query, "per_page": str(per_page)})
-    return data.get("items", []) if data else []
+    items: list[dict] = []
+    max_pages = max(1, _SEARCH_RESULT_WINDOW // per_page)
+    for page in range(1, max_pages + 1):
+        data = _api(f"/search/{endpoint}", {"q": query, "per_page": str(per_page), "page": str(page)})
+        page_items = data.get("items", []) if data else []
+        if not page_items:
+            break
+        items.extend(page_items)
+        if len(page_items) < per_page:
+            break
+    return items
 
 
 # ---------------------------------------------------------------------------

--- a/agent-governance-python/agent-compliance/tests/test_credential_audit.py
+++ b/agent-governance-python/agent-compliance/tests/test_credential_audit.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the packaged credential_audit CLI module."""
+
+from unittest.mock import patch
+
+from agent_compliance.cli import credential_audit
+
+
+class TestSearchPagination:
+    def test_paginates_across_multiple_pages(self):
+        """A full first page must still trigger a request for the next page,
+        not be treated as the end of the results."""
+        pages = {
+            "1": {"items": [{"number": i} for i in range(100)]},
+            "2": {"items": [{"number": i} for i in range(100, 150)]},
+        }
+
+        def fake_api(path, params=None):
+            return pages.get(params["page"])
+
+        with patch.object(credential_audit, "_api", side_effect=fake_api) as mock_api:
+            items = credential_audit._search("issues", "author:x is:issue", per_page=100)
+
+        assert len(items) == 150
+        assert mock_api.call_count == 2
+
+    def test_stops_when_a_short_page_is_returned(self):
+        pages = {"1": {"items": [{"number": 1}, {"number": 2}]}}
+
+        def fake_api(path, params=None):
+            return pages.get(params["page"])
+
+        with patch.object(credential_audit, "_api", side_effect=fake_api) as mock_api:
+            items = credential_audit._search("issues", "author:x is:issue", per_page=100)
+
+        assert len(items) == 2
+        assert mock_api.call_count == 1
+
+    def test_stops_at_github_search_result_window(self):
+        """GitHub's Search API never returns more than 1000 results for a
+        query; a subject with more than that must not cause unbounded
+        pagination."""
+
+        def fake_api(path, params=None):
+            return {"items": [{"number": i} for i in range(int(params["per_page"]))]}
+
+        with patch.object(credential_audit, "_api", side_effect=fake_api) as mock_api:
+            items = credential_audit._search("issues", "author:x is:issue", per_page=100)
+
+        assert len(items) == 1000
+        assert mock_api.call_count == 10
+
+    def test_empty_first_page_returns_no_items(self):
+        with patch.object(credential_audit, "_api", return_value=None) as mock_api:
+            items = credential_audit._search("issues", "author:x is:issue", per_page=100)
+
+        assert items == []
+        assert mock_api.call_count == 1

--- a/scripts/credential_audit.py
+++ b/scripts/credential_audit.py
@@ -86,9 +86,29 @@ def _api(path: str, params: dict[str, str] | None = None) -> Any:
             raise
 
 
+# GitHub's search endpoints cap results at 1000 total (the "Search API"
+# result-window limit, documented at
+# https://docs.github.com/en/rest/search#about-search). A single request
+# only ever returns one page of up to `per_page` items, so a subject with
+# more issues/PRs than fit on the first page silently loses coverage on
+# exactly the pages most likely to contain the later, farther-out citations
+# a real credential spray would produce. Page through the full result
+# window instead of trusting the first response alone.
+_SEARCH_RESULT_WINDOW = 1000
+
+
 def _search(endpoint: str, query: str, per_page: int = 100) -> list[dict]:
-    data = _api(f"/search/{endpoint}", {"q": query, "per_page": str(per_page)})
-    return data.get("items", []) if data else []
+    items: list[dict] = []
+    max_pages = max(1, _SEARCH_RESULT_WINDOW // per_page)
+    for page in range(1, max_pages + 1):
+        data = _api(f"/search/{endpoint}", {"q": query, "per_page": str(per_page), "page": str(page)})
+        page_items = data.get("items", []) if data else []
+        if not page_items:
+            break
+        items.extend(page_items)
+        if len(page_items) < per_page:
+            break
+    return items
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_credential_audit.py
+++ b/scripts/tests/test_credential_audit.py
@@ -15,12 +15,70 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import credential_audit
 from credential_audit import (
     MergeRecord,
     SprayCitation,
     CredentialAuditReport,
     format_report,
 )
+
+
+# ---------------------------------------------------------------------------
+# _search pagination tests
+# ---------------------------------------------------------------------------
+
+class TestSearchPagination:
+    def test_paginates_across_multiple_pages(self):
+        """A short first page must still trigger a request for the next page,
+        not be treated as the end of the results."""
+        pages = {
+            "1": {"items": [{"number": i} for i in range(100)]},
+            "2": {"items": [{"number": i} for i in range(100, 150)]},
+        }
+
+        def fake_api(path, params=None):
+            return pages.get(params["page"])
+
+        with patch.object(credential_audit, "_api", side_effect=fake_api) as mock_api:
+            items = credential_audit._search("issues", "author:x is:issue", per_page=100)
+
+        assert len(items) == 150
+        assert mock_api.call_count == 2
+
+    def test_stops_when_a_short_page_is_returned(self):
+        """A page with fewer than per_page items is the last page; no further
+        request should be made."""
+        pages = {"1": {"items": [{"number": 1}, {"number": 2}]}}
+
+        def fake_api(path, params=None):
+            return pages.get(params["page"])
+
+        with patch.object(credential_audit, "_api", side_effect=fake_api) as mock_api:
+            items = credential_audit._search("issues", "author:x is:issue", per_page=100)
+
+        assert len(items) == 2
+        assert mock_api.call_count == 1
+
+    def test_stops_at_github_search_result_window(self):
+        """GitHub's Search API never returns more than 1000 results for a
+        query; a subject with more than that must not cause unbounded
+        pagination."""
+        def fake_api(path, params=None):
+            return {"items": [{"number": i} for i in range(int(params["per_page"]))]}
+
+        with patch.object(credential_audit, "_api", side_effect=fake_api) as mock_api:
+            items = credential_audit._search("issues", "author:x is:issue", per_page=100)
+
+        assert len(items) == 1000
+        assert mock_api.call_count == 10
+
+    def test_empty_first_page_returns_no_items(self):
+        with patch.object(credential_audit, "_api", return_value=None) as mock_api:
+            items = credential_audit._search("issues", "author:x is:issue", per_page=100)
+
+        assert items == []
+        assert mock_api.call_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

`_search()` in both copies of the credential-audit tool only ever fetches **one page** from GitHub's Search API. `find_spray_citations()` calls it with `per_page=100` and `find_merges()` with `per_page=50`, but neither passes/increments a `page` parameter, so any subject with more issues (or more merged PRs into the target repo) than fit on that first page has every result past it silently dropped - no error, no warning, just an incomplete result set.

GitHub's Search API returns up to **1000 results per query**, paginated (see https://docs.github.com/en/rest/search#about-search). A single unpaginated request only ever sees the first page of that window.

### Why this matters for what the tool is actually for

This is backwards for a credential-spray detector specifically: a contributor prolific enough to have filed more than 100 issues total is also the contributor most likely to have real spray citations sitting on page 2+. As written, the audit can silently report `NONE`/`LOW` risk precisely for the highest-volume accounts it exists to catch, while a low-volume account gets fully covered by chance. Same shape of gap for `find_merges()` and prolific target-repo contributors, though the practical ceiling there (50+ merged PRs into one repo by one person) is a higher bar.

### Fix

Paginate `_search()` through GitHub's full 1000-result window, stopping early when a page comes back shorter than `per_page` (the natural last-page signal). Applied to both copies since they implement this helper independently:
- `agent-governance-python/agent-compliance/src/agent_compliance/cli/credential_audit.py`
- `scripts/credential_audit.py`

### Testing

Added `TestSearchPagination` to both test suites (mocking `_api`), covering:
- multi-page aggregation across a full page + a short page
- stopping immediately on a short first page (no wasted request)
- capping at the 1000-result window when every page comes back full (doesn't loop unboundedly)
- an empty/`None` first-page response returning no items

Ran both suites locally (pytest 9.0.3, Python 3.12.3):
- `scripts/tests/test_credential_audit.py`: 13/13 passed (4 new + 9 existing, no regressions)
- `agent-governance-python/agent-compliance/tests/test_credential_audit.py` (new file) + `test_contributor_check.py`: 7/7 passed

I don't have a real GitHub token with search-API access exercised against live data in this environment, so verification is at the `_search()`/pagination-logic level via mocks, not an end-to-end run of `audit_credentials()` against a live account - flagging that honestly.

### Scope note

`agent_compliance/cli/contributor_check.py`'s `_search_issues()` has the identical single-page pattern at several call sites (`per_page=50`/`100`, no `page` loop) - same underlying gap, different tool. Left untouched here to keep this PR scoped to `credential_audit.py`; happy to send a follow-up if useful.

### AI-assisted contribution disclosure

Per `CONTRIBUTING.md`: this is an AI-assisted contribution (Claude, directed by me) - I reviewed the diff, understand the fix and can explain/defend it, and it is not an autonomous/unreviewed submission, so no additional disclosure is required, but noting it for transparency.