### PR TITLE
fix(claude-code): launch hooks via node directly so they fire on Windows

### DIFF
--- a/agent-governance-claude-code/hooks/hooks.json
+++ b/agent-governance-claude-code/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agt-node",
+            "command": "node",
             "args": [
               "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.mjs"
             ],
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agt-node",
+            "command": "node",
             "args": [
               "${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit.mjs"
             ],
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agt-node",
+            "command": "node",
             "args": [
               "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use.mjs"
             ],


### PR DESCRIPTION
## Problem

`hooks/hooks.json` launches every hook through `bin/agt-node`, an extensionless POSIX sh script. Claude Code spawns hook commands without a shell, so on win32 that path never executes: SessionStart, UserPromptSubmit, and PreToolUse silently never fire — enforce mode runs with no gating and an empty audit log. An explicit `.cmd` reference does not spawn either; only a bare executable name resolvable to an `.exe` works.

## Fix

Invoke `node` directly with the hook script as its argument. `agt-node` was a pure passthrough to node, so behavior on POSIX platforms is unchanged.

## Validation

- On Windows 11, a headless probe session confirms the extensionless and `.cmd` launcher forms never run while bare `node` does; with this change a `--plugin-dir` session writes `prompt.submit` audit entries again.
- `npm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
