### PR TITLE
fix(claude-code): use newline-delimited JSON for MCP stdio framing

### DIFF
--- a/agent-governance-claude-code/server/agt-mcp.mjs
+++ b/agent-governance-claude-code/server/agt-mcp.mjs
@@ -82,8 +82,8 @@ export async function handleJsonRpcRequest(state, request) {
 }
 
 export function encodeJsonRpcMessage(message) {
-  const body = JSON.stringify(message);
-  return `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`;
+  // MCP stdio transport: newline-delimited JSON, not LSP Content-Length framing.
+  return `${JSON.stringify(message)}\n`;
 }
 
 async function callTool(state, params) {

--- a/agent-governance-claude-code/test/mcp-server.test.mjs
+++ b/agent-governance-claude-code/test/mcp-server.test.mjs
@@ -52,7 +52,7 @@ test("tools/call rejects invalid agt_policy_check_text arguments", async () => {
   assert.match(response.result.content[0].text, /requires a string 'text' argument/i);
 });
 
-test("encoded JSON-RPC messages include a content-length header", () => {
+test("encoded JSON-RPC messages are newline-delimited JSON", () => {
   const encoded = encodeJsonRpcMessage({
     jsonrpc: "2.0",
     id: 4,
@@ -61,6 +61,11 @@ test("encoded JSON-RPC messages include a content-length header", () => {
     },
   });
 
-  assert.match(encoded, /^Content-Length: \d+\r\n\r\n/);
-  assert.match(encoded, /"ok":true/);
+  assert.ok(encoded.endsWith("\n"));
+  assert.equal(encoded.indexOf("\n"), encoded.length - 1);
+  assert.deepEqual(JSON.parse(encoded), {
+    jsonrpc: "2.0",
+    id: 4,
+    result: { ok: true },
+  });
 });


### PR DESCRIPTION
## Problem

`server/agt-mcp.mjs` encodes JSON-RPC responses with LSP-style `Content-Length` headers, but the MCP stdio transport specifies newline-delimited JSON messages. Clients speaking the spec (including Claude Code) fail to parse the framed responses, so `agt_policy_status` and `agt_policy_check_text` never return results.

## Fix

Encode each message as a single JSON line. The framing test is updated to assert newline-delimited output.

## Validation

- `npm test` green.
- Verified in a live Claude Code session: both MCP tools respond after the change and time out before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
