### PR TITLE
fix(claude-code): make the recursive-delete policy pattern match real rm -rf

### DIFF
--- a/agent-governance-claude-code/config/default-policy.json
+++ b/agent-governance-claude-code/config/default-policy.json
@@ -38,7 +38,7 @@
       "effect": "deny",
       "commandPatterns": [
         {
-          "source": "\\brm\\b[\\s\\S]*\\b-rf\\b",
+          "source": "\\brm\\b[\\s\\S]*\\s-(?:rf|fr)\\b",
           "flags": "i"
         }
       ]

--- a/agent-governance-claude-code/test/policy.test.mjs
+++ b/agent-governance-claude-code/test/policy.test.mjs
@@ -81,6 +81,43 @@ test("evaluatePreToolUse denies dangerous bootstrap and reviews persistence writ
   await rm(root, { recursive: true, force: true });
 });
 
+test("evaluatePreToolUse denies recursive deletes but allows safe cleanup targets", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-claude-rm-"));
+  const auditPath = join(root, "audit.json");
+  const state = await loadPolicy({
+    auditPath,
+    policyPath: join(root, "no-user-policy.json"),
+  });
+
+  const denyResult = await evaluatePreToolUse(state, {
+    tool_name: "Bash",
+    tool_input: {
+      command: "rm -rf src",
+    },
+    session_id: "rm-deny-session",
+    cwd: root,
+  });
+
+  assert.equal(denyResult.hookSpecificOutput.permissionDecision, "deny");
+  assert.match(
+    denyResult.hookSpecificOutput.permissionDecisionReason,
+    /recursive delete/i,
+  );
+
+  const cleanupResult = await evaluatePreToolUse(state, {
+    tool_name: "Bash",
+    tool_input: {
+      command: "rm -rf node_modules",
+    },
+    session_id: "rm-cleanup-session",
+    cwd: root,
+  });
+
+  assert.notEqual(cleanupResult.hookSpecificOutput.permissionDecision, "deny");
+
+  await rm(root, { recursive: true, force: true });
+});
+
 test("evaluatePreToolUse denies Windows-style secret reads", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-claude-windows-secret-"));
   const auditPath = join(root, "audit.json");


### PR DESCRIPTION
## Problem

The bundled `recursive-delete` rule uses the pattern `\brm\b[\s\S]*\b-rf\b`. There is no word boundary between a space and a hyphen, so `\b-rf\b` can never match the command form `rm -rf <target>` — it only matches the nonsense form `rm-rf`. The flagship dangerous-delete rule is dead code: every `rm -rf` sails through the command-pattern backend unmatched.

## Fix

Require whitespace before the flag and accept both orderings: `\s-(?:rf|fr)\b`. Combined single-dash flags in other orders (e.g. `-vrf`) and long-form `--recursive --force` remain out of scope of this minimal fix.

## Validation

- New regression test: `rm -rf src` must be denied with the recursive-delete reason (pinned to the rule's reason string so it cannot pass via the MCP scanner), while the documented safe-cleanup bypass (`rm -rf node_modules`) must still not deny. The test is red against the old pattern and green with the fix.
- The test pins `loadPolicy` to a nonexistent user policy path so a developer's real `~/.claude/agt/policy.json` cannot affect it.
- `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
