### PR TITLE
fix(contributor-check): retry subprocess calls with backoff before returning UNKNOWN

### DIFF
--- a/scripts/contributor_check_action.py
+++ b/scripts/contributor_check_action.py
@@ -74,8 +74,7 @@ def _run_check(
     Retries the subprocess call with exponential backoff before giving up.
     A single transient failure (a GitHub API blip inside the child script, a
     momentary timeout) no longer collapses straight to UNKNOWN: UNKNOWN now
-    means "checked and could not determine", not "one call failed". See
-    agentrust-io/.github#27.
+    means "checked and could not determine", not "one call failed".
     """
     last_exc: Exception | None = None
     for attempt in range(max_attempts):

--- a/scripts/contributor_check_action.py
+++ b/scripts/contributor_check_action.py
@@ -24,6 +24,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
@@ -60,25 +61,50 @@ def _api(token: str, method: str, path: str, data: dict | None = None) -> dict |
         raise
 
 
-def _run_check(script: str, args: list[str], out_path: str) -> str:
-    """Run a check script and return the risk level from its JSON output."""
-    try:
-        result = subprocess.run(
-            [sys.executable, script, *args, "--json"],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        Path(out_path).write_text(result.stdout)
-        data = json.loads(result.stdout)
-        risk = data.get("risk", "UNKNOWN")
-        # credential_audit returns "NONE" when a user has no merged PRs in the
-        # target repo (nothing to launder = not applicable). Normalize to "LOW"
-        # so it aggregates correctly rather than being treated as UNKNOWN (which
-        # is reserved for checks that errored or could not be determined).
-        return "LOW" if risk == "NONE" else risk
-    except Exception:
-        return "UNKNOWN"
+def _run_check(
+    script: str,
+    args: list[str],
+    out_path: str,
+    *,
+    max_attempts: int = 3,
+    base_delay: float = 2.0,
+) -> str:
+    """Run a check script and return the risk level from its JSON output.
+
+    Retries the subprocess call with exponential backoff before giving up.
+    A single transient failure (a GitHub API blip inside the child script, a
+    momentary timeout) no longer collapses straight to UNKNOWN: UNKNOWN now
+    means "checked and could not determine", not "one call failed". See
+    agentrust-io/.github#27.
+    """
+    last_exc: Exception | None = None
+    for attempt in range(max_attempts):
+        try:
+            result = subprocess.run(
+                [sys.executable, script, *args, "--json"],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            Path(out_path).write_text(result.stdout)
+            data = json.loads(result.stdout)
+            risk = data.get("risk", "UNKNOWN")
+            # credential_audit returns "NONE" when a user has no merged PRs in the
+            # target repo (nothing to launder = not applicable). Normalize to "LOW"
+            # so it aggregates correctly rather than being treated as UNKNOWN (which
+            # is reserved for checks that errored or could not be determined).
+            return "LOW" if risk == "NONE" else risk
+        except Exception as exc:  # subprocess/parse failures are the retry target
+            last_exc = exc
+            if attempt < max_attempts - 1:
+                time.sleep(base_delay * (2**attempt))
+                continue
+
+    print(
+        f"  contributor-check subprocess failed after {max_attempts} attempts: {last_exc}",
+        file=sys.stderr,
+    )
+    return "UNKNOWN"
 
 
 def _aggregate_risk(*levels: str) -> str:

--- a/scripts/tests/test_contributor_check_action.py
+++ b/scripts/tests/test_contributor_check_action.py
@@ -100,13 +100,62 @@ def test_run_check_high_passes_through():
 
 
 def test_run_check_crash_returns_unknown():
-    # A script that crashes must not silently score as LOW.
+    # A script that crashes on every attempt must not silently score as LOW,
+    # and must exhaust its retries before giving up. base_delay is tiny here
+    # only to keep the test fast; production uses the real default.
     with tempfile.TemporaryDirectory() as tmp:
         path = os.path.join(tmp, "crasher.py")
         with open(path, "w") as f:
             f.write("raise RuntimeError('simulated failure')\n")
         out = os.path.join(tmp, "out.json")
-        assert _run_check(path, [], out) == "UNKNOWN"
+        assert _run_check(path, [], out, max_attempts=2, base_delay=0.01) == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# _run_check retry with backoff (issue agentrust-io/.github#27)
+# ---------------------------------------------------------------------------
+
+def _make_flaky_script(fail_times: int, risk: str, tmp_dir: str) -> str:
+    """A script that fails the first `fail_times` invocations, then succeeds.
+
+    Uses a counter file on disk since each invocation is a fresh subprocess.
+    """
+    counter_path = os.path.join(tmp_dir, "counter.txt")
+    with open(counter_path, "w") as f:
+        f.write("0")
+    path = os.path.join(tmp_dir, "flaky.py")
+    with open(path, "w") as f:
+        f.write(textwrap.dedent(f"""\
+            import json
+            counter_path = {counter_path!r}
+            with open(counter_path) as fh:
+                n = int(fh.read().strip())
+            n += 1
+            with open(counter_path, "w") as fh:
+                fh.write(str(n))
+            if n <= {fail_times}:
+                raise RuntimeError("simulated transient failure")
+            print(json.dumps({{"risk": "{risk}"}}))
+        """))
+    return path
+
+
+def test_run_check_retries_transient_failure_then_succeeds():
+    # First attempt fails (e.g. a GitHub API blip inside the child script);
+    # the retry succeeds. The single failure must not surface as UNKNOWN.
+    with tempfile.TemporaryDirectory() as tmp:
+        script = _make_flaky_script(fail_times=1, risk="LOW", tmp_dir=tmp)
+        out = os.path.join(tmp, "out.json")
+        assert _run_check(script, [], out, max_attempts=3, base_delay=0.01) == "LOW"
+
+
+def test_run_check_exhausts_retries_before_returning_unknown():
+    # A script that never succeeds must still end in UNKNOWN, but only after
+    # max_attempts tries -- not on the first failure.
+    with tempfile.TemporaryDirectory() as tmp:
+        script = _make_flaky_script(fail_times=99, risk="LOW", tmp_dir=tmp)
+        out = os.path.join(tmp, "out.json")
+        assert _run_check(script, [], out, max_attempts=2, base_delay=0.01) == "UNKNOWN"
 
 
 def test_run_check_none_plus_low_aggregate_stays_low():


### PR DESCRIPTION
## Related Issue
Related to agentrust-io/.github#27


## Problem & Solution

Problem:
In scripts/contributor_check_action.py, the _run_check() function runs each contributor-risk check as a subprocess and if that subprocess fails for any reason even a one-off network blip or a slow GitHub API response can make it immediately give up and returns "UNKNOWN" also, there's no retry at all.

As UNKNOWN is ranked above LOW on purpose (a check that couldn't run should look more suspicious than a clean one, not less), this small hiccup ends up making completely normal, trusted contributors show up as "needs-review: UNKNOWN". This isn't theoretical as it is already happening on three real submissions (linked in agentrust-io/.github#27).

Solution: 
Added a small retry loop with exponential backoff inside _run_check(). It tries up to 3 times by default (2s wait, then 4s) before it finally returns UNKNOWN. so, UNKNOWN now actually means "we tried and couldn't tell", not "one call happened to fail once."

## Impact on Your Work
was looking into this issue agentrust-io/.github#27 and it traced back to this repo, so the actual fix has to happen here rather than in .github.

## Timeline
None

## Alternatives Considered
first looked at fixing this from the agentrust-io/.github side (adding a retry around the whole action). But that doesn't work as the Python script already catches its own exceptions and exits with code 0 even when it silently falls back to UNKNOWN, so there's nothing for an outer retry to trigger on. The fix has to sit inside _run_check() itself, where the actual subprocess call is happening.

kept the retry narrow intentionally, as only around the subprocess call inside _run_check() instead of touching the bigger scripts/ vs agent_compliance/cli/ divergence tracked in #3571 / PR #3803. That's a separate, larger reconciliation effort, and I didn't want this small fix to get tangled up in it or add merge conflicts.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
**Core & runtime:**
- [ ] agent-governance-toolkit-core
- [ ] agent-primitives
- [ ] agent-os
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-compliance

**Governance & security:**
- [ ] agent-mcp-governance
- [ ] agent-rag-governance
- [ ] agent-sandbox
- [ ] agent-discovery
- [ ] agt-policies
- [ ] policy-engine

**Platform & tooling:**
- [ ] agent-hypervisor
- [ ] agent-lightning
- [ ] agent-marketplace
- [ ] agent-governance-toolkit-cli
- [ ] agent-governance-toolkit-integrations
- [ ] agent-governance-toolkit-protocols
- [ ] agentmesh-integrations (framework integrations)

**CLI plugins:**
- [ ] agent-governance CLI plugins (copilot-cli / claude-code / opencode / antigravity-cli)

**Shared / other:**
- [ ] schemas
- [ ] action (GitHub Action)
- [ ] examples
- [ ] docs / root

## Testing
<!-- Describe how you verified this change. -->

### Unit Testing
Added two new tests in scripts/tests/test_contributor_check_action.py:

- test_run_check_retries_transient_failure_then_succeeds - a check script that fails once, then succeeds on retry; confirms the result is the real risk level, not UNKNOWN.
- test_run_check_exhausts_retries_before_returning_unknown - a check script that fails every time; confirms it still returns UNKNOWN, but only after all retries are used up, not on the first failure.

### Manual Testing
<!-- What did you run by hand to verify this change (commands, environment, results)? -->
<!-- Write "N/A" if manual testing does not apply. -->

## Checklist
- [x] I have linked a related issue above, or completed "Problem & Solution", "Impact on Your Work", and "Alternatives Considered"
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
<!-- REQUIRED for new features, integrations, or architectural patterns -->
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
None

## AI Assistance
<!-- See CONTRIBUTING.md "AI-Assisted Contributions" for full policy -->
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
<!-- Example: "GitHub Copilot for boilerplate, Codex for test generation — all output reviewed" -->
<!-- Leave blank if AI was not used or was only used for minor assistance -->

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License
