### PR TITLE
test(agent-mesh): make approval timeout test deterministic

### DIFF
--- a/agent-governance-python/agent-mesh/tests/test_approval_strict.py
+++ b/agent-governance-python/agent-mesh/tests/test_approval_strict.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 
 import pytest
 
-import agentmesh.governance.approval as approval_module
 from agentmesh.governance.approval import (
     ApprovalDecision,
     ApprovalRequest,
@@ -56,11 +55,11 @@ class TestCallbackTimeoutDeprecation:
             CallbackApproval(_cb(), on_timeout="allow", strict=False)
 
     def test_timeout_always_denies(self, monkeypatch):
-        # Use a deterministic clock rather than real sleep. Windows monotonic
-        # clocks may have coarser resolution than a short test sleep.
+        # Patch the exact function-global clock so the test is deterministic
+        # even when package consolidation loads the implementation elsewhere.
         ticks = iter((100.0, 100.001))
-        monkeypatch.setattr(
-            approval_module,
+        monkeypatch.setitem(
+            CallbackApproval.request_approval.__globals__,
             "time",
             SimpleNamespace(monotonic=lambda: next(ticks)),
         )

--- a/agent-governance-python/agent-mesh/tests/test_approval_strict.py
+++ b/agent-governance-python/agent-mesh/tests/test_approval_strict.py
@@ -3,12 +3,13 @@
 """Deprecation + strict mode for unsafe legacy approval behaviors (ADR-0030 step 5)."""
 
 import json
-import time
 import urllib.request
 import warnings
+from types import SimpleNamespace
 
 import pytest
 
+import agentmesh.governance.approval as approval_module
 from agentmesh.governance.approval import (
     ApprovalDecision,
     ApprovalRequest,
@@ -54,13 +55,23 @@ class TestCallbackTimeoutDeprecation:
         with pytest.raises(ValueError, match="on_timeout"):
             CallbackApproval(_cb(), on_timeout="allow", strict=False)
 
-    def test_timeout_always_denies(self):
-        # Behavior unchanged: a timeout denies regardless of on_timeout.
+    def test_timeout_always_denies(self, monkeypatch):
+        # Use a deterministic clock rather than real sleep. Windows monotonic
+        # clocks may have coarser resolution than a short test sleep.
+        ticks = iter((100.0, 100.001))
+        monkeypatch.setattr(
+            approval_module,
+            "time",
+            SimpleNamespace(monotonic=lambda: next(ticks)),
+        )
+
         handler = CallbackApproval(
-            lambda r: (time.sleep(0.005) or ApprovalDecision(approved=True, approver="x")),
+            lambda r: ApprovalDecision(approved=True, approver="x"),
             timeout_seconds=0,
         )
+
         decision = handler.request_approval(_req())
+
         assert not decision.approved
         assert decision.approver == "system:timeout"
 


### PR DESCRIPTION
## Related Issue

No dedicated issue. The affected regression was introduced as part of #3106.

## Problem & Solution

**Problem:** `TestCallbackTimeoutDeprecation.test_timeout_always_denies` relied on `time.sleep(0.005)` and a subsequent `time.monotonic()` delta. On Windows, the monotonic clock in the local test environment reported a resolution of 15.625 ms, so a 5 ms sleep could still produce an observed elapsed time of `0.0`. With `timeout_seconds=0`, the test could therefore return the callback's approval instead of exercising the timeout-denial branch.

This made the security regression test intermittently fail even though the implementation remained fail-closed when an elapsed timeout was actually observed.

**Solution:** replace the real-clock sleep with deterministic monotonic values in the test. The test patches the exact `CallbackApproval.request_approval` function-global clock for the duration of the test, so it always observes a positive elapsed interval and verifies the intended `system:timeout` denial without depending on host timer granularity.

Production approval code is unchanged.

## Impact on Your Work

The flaky test blocked a clean AgentMesh approval-test baseline on Windows and made repeated local verification unreliable. This change preserves the existing security assertion while making the regression deterministic and portable across platforms.

## Timeline

None.

## Alternatives Considered

- **Increase the sleep duration.** This would reduce the likelihood of failure but would still depend on operating-system scheduling and clock resolution, while making the test slower.
- **Patch `time.monotonic` through a separately imported module alias.** This was tested first, but the consolidated package layout can load the implementation through a different module object in editable or local installations. Patching the function's own globals targets the clock actually resolved by the implementation.
- **Change the production timeout comparison.** This was rejected because the failure was caused by the test's timing assumption rather than by the production fail-closed behaviour.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected

**Core & runtime:**
- [ ] agent-governance-toolkit-core
- [ ] agent-primitives
- [ ] agent-os
- [x] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-compliance

**Governance & security:**
- [ ] agent-mcp-governance
- [ ] agent-rag-governance
- [ ] agent-sandbox
- [ ] agent-discovery
- [ ] agt-policies
- [ ] policy-engine

**Platform & tooling:**
- [ ] agent-hypervisor
- [ ] agent-lightning
- [ ] agent-marketplace
- [ ] agent-governance-toolkit-cli
- [ ] agent-governance-toolkit-integrations
- [ ] agent-governance-toolkit-protocols
- [ ] agentmesh-integrations (framework integrations)

**CLI plugins:**
- [ ] agent-governance CLI plugins (copilot-cli / claude-code / opencode / antigravity-cli)

**Shared / other:**
- [ ] schemas
- [ ] action (GitHub Action)
- [ ] examples
- [ ] docs / root

## Testing

### Unit Testing

- AgentMesh approval-focused suite: `76 passed`.
- The previously flaky timeout-denial regression now passes with a deterministic clock.
- Three existing package-consolidation deprecation warnings remain unchanged.

### Manual Testing

Verified locally on Windows with Python 3.12:

- `python -m pip check` — `No broken requirements found.`
- `python -m ruff check agent-governance-python/agent-mesh/tests/test_approval_strict.py` — `All checks passed!`
- Working tree clean after verification.

## Checklist

- [x] I have linked a related issue above, or completed "Problem & Solution", "Impact on Your Work", and "Alternatives Considered"
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

The full AgentMesh package suite has not been run locally; the focused approval suite passed cleanly. The CLA checkbox is intentionally left open for the repository's CLA bot to confirm.

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

None.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

ChatGPT was used to help diagnose the Windows timer-resolution failure and draft the deterministic test change. The exact diff was reviewed and the validation commands were run locally before submission.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License