### PR TITLE
fix: update policy engine SHA1 dependency

### DIFF
--- a/docs/dependency-audits/2026-08-27-policy-engine-sha1-0.10.7.md
+++ b/docs/dependency-audits/2026-08-27-policy-engine-sha1-0.10.7.md
@@ -1,0 +1,34 @@
+---
+title: Policy Engine SHA1 0.10.7 Lockfile Update
+last_reviewed: 2026-08-27
+owner: agt-maintainers
+---
+
+# Policy Engine SHA1 0.10.7 Lockfile Update
+
+## Which Dependencies Changed And Why
+
+- `policy-engine/Cargo.lock` updates `sha1` from `0.10.6` to `0.10.7`.
+- The checksum changes to the crates.io checksum for `sha1 0.10.7`.
+- No manifest, source file, or other dependency version changes.
+
+The patch keeps the policy-engine lockfile on the latest compatible `sha1`
+release accepted by the existing transitive dependency constraints.
+
+## Security Advisory Relevance
+
+- S360 work item `246401` and Component Governance alert `16259049` report
+  `MVS-2022-374v-6mvc` for `sha1 0.10.6` in the policy-engine dependency
+  graph.
+- This update removes `sha1 0.10.6` from the committed lockfile and resolves
+  `sha1 0.10.7` instead.
+
+## Breaking Change Risk Assessment
+
+- Risk is low because this is a patch-level lockfile update within the
+  existing `sha1 0.10.x` constraint.
+- No public API, policy behavior, feature selection, or manifest constraint
+  changes.
+- `cargo check --workspace --locked`, `cargo fmt --all -- --check`,
+  `cargo clippy --workspace --all-targets --locked -- -D warnings`, and
+  `cargo test --workspace --locked` pass.

--- a/policy-engine/Cargo.lock
+++ b/policy-engine/Cargo.lock
@@ -2974,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",


### PR DESCRIPTION
## Why

S360 and Component Governance flag `sha1 0.10.6` in the policy-engine lockfile under `MVS-2022-374v-6mvc`. The available `0.10.7` patch removes the flagged lockfile version without changing policy runtime APIs.

## Vulnerability

- Advisory: `MVS-2022-374v-6mvc`
- S360 work item: [AB#246401](https://dev.azure.com/AIP-RAI-Eng/d4b9f9c5-d834-47cc-b89c-31db2239a786/_workitems/edit/246401)
- [Component Governance alert 16259049](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_componentGovernance/236562?alertId=16259049&branchMoniker=main)

## Change

Update the shared policy-engine lockfile from `sha1 0.10.6` to `0.10.7`. No manifests or runtime source files change.

## Validation

- `cargo check --workspace --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`