### PR TITLE
fix: update Rust SDK AES dependency

### DIFF
--- a/agent-governance-rust/Cargo.lock
+++ b/agent-governance-rust/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -2326,7 +2326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/docs/dependency-audits/2026-08-27-rust-sdk-aes-0.9.2.md
+++ b/docs/dependency-audits/2026-08-27-rust-sdk-aes-0.9.2.md
@@ -6,6 +6,8 @@ owner: agt-maintainers
 
 # Rust SDK AES 0.9.2 Lockfile Update
 
+<!-- cspell:ignore getrandom -->
+
 ## Which Dependencies Changed And Why
 
 - `agent-governance-rust/Cargo.lock` updates `aes` from `0.9.1` to `0.9.2`.

--- a/docs/dependency-audits/2026-08-27-rust-sdk-aes-0.9.2.md
+++ b/docs/dependency-audits/2026-08-27-rust-sdk-aes-0.9.2.md
@@ -1,0 +1,35 @@
+---
+title: Rust SDK AES 0.9.2 Lockfile Update
+last_reviewed: 2026-08-27
+owner: agt-maintainers
+---
+
+# Rust SDK AES 0.9.2 Lockfile Update
+
+## Which Dependencies Changed And Why
+
+- `agent-governance-rust/Cargo.lock` updates `aes` from `0.9.1` to `0.9.2`.
+- The checksum changes to the crates.io checksum for `aes 0.9.2`.
+- Cargo also normalizes the existing target-specific `tempfile` dependency
+  edge from the locked `getrandom 0.4.2` entry to the already locked
+  `getrandom 0.3.4` entry. No `getrandom` package version is added or removed.
+- No manifest, SDK source, or other package version changes.
+
+The existing `aes-gcm 0.11.0` constraint accepts the patched `aes` release,
+so no source or public dependency constraint change is required.
+
+## Security Advisory Relevance
+
+- S360 work item `329434` and Component Governance alert `17536943` report
+  `MVS-2022-374v-6mvc` for `aes 0.9.1` in the Rust SDK dependency graph.
+- `cargo tree --locked -i aes` confirms that `aes-gcm 0.11.0` now resolves
+  `aes 0.9.2` and that `aes 0.9.1` is absent.
+
+## Breaking Change Risk Assessment
+
+- Risk is low because `aes` receives a patch-level update under the existing
+  `aes-gcm` dependency constraint.
+- No encryption API, credential-vault source, public API, or feature selection
+  changes.
+- `cargo build --release --workspace --locked` and
+  `cargo test --release --workspace --locked` pass.


### PR DESCRIPTION
## Why

S360 and Component Governance flag `aes 0.9.1` in the Rust SDK dependency graph under `MVS-2022-374v-6mvc`. The compatible `0.9.2` patch is available through the existing `aes-gcm 0.11.0` dependency.

## Vulnerability

- Advisory: `MVS-2022-374v-6mvc`
- S360 work item: [AB#329434](https://dev.azure.com/AIP-RAI-Eng/d4b9f9c5-d834-47cc-b89c-31db2239a786/_workitems/edit/329434)
- [Component Governance alert 17536943](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_componentGovernance/236562?alertId=17536943&branchMoniker=main)

## Change

Update the Rust SDK lockfile from `aes 0.9.1` to `0.9.2`. The existing `aes-gcm` declaration and SDK source remain unchanged.

## Validation

- `cargo tree --locked -i aes` resolves `aes 0.9.2` through `aes-gcm 0.11.0`
- `cargo build --release --workspace --locked`
- `cargo test --release --workspace --locked`