### PR TITLE
fix: update Antigravity js-yaml override

### DIFF
--- a/agent-governance-antigravity-cli/package-lock.json
+++ b/agent-governance-antigravity-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/agent-governance-antigravity-cli",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/agent-governance-antigravity-cli",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@microsoft/agent-governance-sdk": "4.0.0"
@@ -16,9 +16,6 @@
       },
       "engines": {
         "node": ">=20.19.0"
-      },
-      "overrides": {
-        "js-yaml": "4.2.0"
       }
     },
     "node_modules/@microsoft/agent-governance-sdk": {
@@ -92,9 +89,19 @@
       "license": "Python-2.0"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/agent-governance-antigravity-cli/package.json
+++ b/agent-governance-antigravity-cli/package.json
@@ -36,7 +36,7 @@
     "@microsoft/agent-governance-sdk": "4.0.0"
   },
   "overrides": {
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.1"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/docs/dependency-audits/2026-08-27-antigravity-js-yaml-4.3.1.md
+++ b/docs/dependency-audits/2026-08-27-antigravity-js-yaml-4.3.1.md
@@ -6,6 +6,8 @@ owner: agt-maintainers
 
 # Antigravity CLI js-yaml 4.3.1 Update
 
+<!-- cspell:ignore xmqj -->
+
 ## Which Dependencies Changed And Why
 
 - `agent-governance-antigravity-cli/package.json` updates the existing

--- a/docs/dependency-audits/2026-08-27-antigravity-js-yaml-4.3.1.md
+++ b/docs/dependency-audits/2026-08-27-antigravity-js-yaml-4.3.1.md
@@ -1,0 +1,36 @@
+---
+title: Antigravity CLI js-yaml 4.3.1 Update
+last_reviewed: 2026-08-27
+owner: agt-maintainers
+---
+
+# Antigravity CLI js-yaml 4.3.1 Update
+
+## Which Dependencies Changed And Why
+
+- `agent-governance-antigravity-cli/package.json` updates the existing
+  transitive `js-yaml` override from `4.2.0` to `4.3.1`.
+- `agent-governance-antigravity-cli/package-lock.json` resolves `js-yaml`
+  at `4.3.1` and records its registry integrity and funding metadata.
+- Regenerating the lockfile also aligns the root package metadata from stale
+  version `4.0.0` to the manifest's current version `5.0.0`.
+- No other dependency version or runtime source changes.
+
+The override remains necessary because
+`@microsoft/agent-governance-sdk 4.0.0` requests `js-yaml 4.1.1` transitively.
+
+## Security Advisory Relevance
+
+- S360 work item `332698` and Component Governance alert `17967443` report
+  `CVE-2026-59869` for `js-yaml 4.2.0` in this package lockfile.
+- S360 work item `341592` and Component Governance alert `18612941` report
+  `GHSA-5p4m-2wfm-xmqj` for the same installed package instance.
+- `npm ls js-yaml` confirms the SDK dependency resolves to overridden
+  `js-yaml 4.3.1`, and `npm ci` reports zero vulnerabilities.
+
+## Breaking Change Risk Assessment
+
+- Risk is low because `js-yaml` receives a patch-level update within 4.x and
+  remains an override of the same transitive dependency.
+- No CLI source, command behavior, or public package API changes.
+- `npm run check` and `npm test` pass all 22 Antigravity tests.


### PR DESCRIPTION
## Why

S360 and Component Governance flag the Antigravity CLI's overridden `js-yaml 4.2.0` for two related advisories. Both alerts apply to the same installed package instance, so one override and lockfile update is the smallest complete remediation.

## Vulnerabilities

- `CVE-2026-59869`: [AB#332698](https://dev.azure.com/AIP-RAI-Eng/d4b9f9c5-d834-47cc-b89c-31db2239a786/_workitems/edit/332698) and [Component Governance alert 17967443](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_componentGovernance/236562?alertId=17967443&branchMoniker=main)
- `GHSA-5p4m-2wfm-xmqj`: [AB#341592](https://dev.azure.com/AIP-RAI-Eng/d4b9f9c5-d834-47cc-b89c-31db2239a786/_workitems/edit/341592) and [Component Governance alert 18612941](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_componentGovernance/236562?alertId=18612941&branchMoniker=main)

## Change

Update only the Antigravity package's transitive `js-yaml` override and lockfile from `4.2.0` to `4.3.1`.

## Validation

- `npm ci` reports zero vulnerabilities
- `npm ls js-yaml` resolves `js-yaml 4.3.1 overridden`
- `npm run check`
- `npm test` passes 22 tests