### PR TITLE
chore: allow Buildx in spell checks

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -286,6 +286,7 @@ bluebubbles
 bmod
 bubblewrap
 buildkit
+buildx
 bursty
 bypassable
 bytearray


### PR DESCRIPTION
## Summary

- add the Docker Buildx product name to the repository spelling dictionary
- unblock workflow pin updates such as #3828 without adding per-file spelling suppressions

## Validation

- `cspell@8.17.3` passes the exact changed workflow and PR-title text from #3828

Related: #3828