### PR TITLE
test: stabilize OPA timeout regression

### DIFF
--- a/policy-engine/core/tests/opa.rs
+++ b/policy-engine/core/tests/opa.rs
@@ -251,7 +251,7 @@ exec sleep 30
     let dispatcher = OpaPolicyDispatcher::with_runner(
         OpaRegoRunner::new()
             .with_executable(&fake_opa)
-            .with_eval_timeout(Duration::from_millis(30)),
+            .with_eval_timeout(Duration::from_millis(500)),
     );
     let error = dispatcher
         .evaluate(&rego_invocation(


### PR DESCRIPTION
## Summary
- increase the fake OPA timeout test budget from 30 ms to 500 ms
- avoid racing the fake OPA script before it writes the PID file on slower local environments

## Repro
Before this change, running the core package tests on this machine failed in `opa_timeout_kills_child_process_without_lingering` because `core/tests/opa.rs` attempted to read a PID file that had not been written yet.

## Test
- `cargo test -p agent_control_specification_core --test opa --quiet`
- `cargo test -p agent_control_specification_core --quiet`

Signed-off-by: Debjyoti Paul <debjyotipaul@users.noreply.github.com>
