### PR TITLE
fix(agent-os): apply TLS floor to unregistered MCP servers in auth fallback

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
@@ -90,6 +90,11 @@ class McpAuthPolicy:
         deny_none: Whether to deny connections with auth_method="none".
             Default True (fail-closed).
         servers: Explicit per-server auth method allowlist.
+        default_require_tls: Whether the TLS floor applied to registered
+            entries also applies to servers not in the allowlist (the
+            fallback path below). Default True (fail-closed); an unregistered
+            server name should not get weaker transport guarantees than a
+            registered one.
     """
 
     def __init__(
@@ -97,9 +102,11 @@ class McpAuthPolicy:
         default_allowed_methods: list[str] | None = None,
         deny_none: bool = True,
         servers: list[McpServerEntry] | None = None,
+        default_require_tls: bool = True,
     ):
         self._default_methods = set(default_allowed_methods or ["oauth2", "mtls", "bearer"])
         self._deny_none = deny_none
+        self._default_require_tls = default_require_tls
         self._servers: dict[str, McpServerEntry] = {}
         for s in (servers or []):
             self._servers[s.name] = s
@@ -186,6 +193,26 @@ class McpAuthPolicy:
 
         # Fall back to default policy
         if auth_method in self._default_methods:
+            # TLS check: an unregistered server name should not get weaker
+            # transport guarantees than a registered one. Only enforced when
+            # a URL is actually supplied — an omitted/empty URL stays
+            # allowed here too, matching the registered-entry gate above.
+            if self._default_require_tls and url:
+                try:
+                    scheme = urlparse(url).scheme.lower()
+                except (ValueError, AttributeError):
+                    scheme = ""
+                if scheme not in {"https", "wss"}:
+                    return AuthCheckResult(
+                        allowed=False,
+                        server_name=server_name,
+                        auth_method=auth_method,
+                        reason=(
+                            f"Server '{server_name}' is not in the allowlist; the default "
+                            f"policy requires TLS but URL scheme {scheme!r} is not in the "
+                            f"TLS allowlist (https, wss)"
+                        ),
+                    )
             return AuthCheckResult(
                 allowed=True,
                 server_name=server_name,
@@ -237,4 +264,5 @@ class McpAuthPolicy:
             default_allowed_methods=policy_data.get("default_allowed_methods"),
             deny_none=policy_data.get("deny_none", True),
             servers=servers,
+            default_require_tls=policy_data.get("default_require_tls", True),
         )

--- a/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
@@ -106,6 +106,24 @@ class TestMcpAuthPolicy:
         assert result.allowed
         assert len(result.reason) > 0
 
+    def test_unregistered_server_with_url_still_requires_tls(self):
+        # Regression for #3814: a server name absent from the allowlist used
+        # to skip the TLS gate entirely, even with a plain-http URL.
+        policy = McpAuthPolicy()
+        result = policy.check("typo-d-server", auth_method="oauth2", url="http://mcp.internal/tools")
+        assert not result.allowed
+        assert "tls" in result.reason.lower()
+
+    def test_unregistered_server_with_https_url_is_allowed(self):
+        policy = McpAuthPolicy()
+        result = policy.check("new-server", auth_method="oauth2", url="https://mcp.internal/tools")
+        assert result.allowed
+
+    def test_unregistered_server_default_tls_floor_can_be_disabled(self):
+        policy = McpAuthPolicy(default_require_tls=False)
+        result = policy.check("legacy-server", auth_method="oauth2", url="http://mcp.internal/tools")
+        assert result.allowed
+
 
 class TestFromYaml:
     def test_parse_yaml(self):

--- a/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
@@ -148,3 +148,20 @@ mcp_auth_policy:
     def test_empty_yaml(self):
         policy = McpAuthPolicy.from_yaml("")
         assert policy.check("s", auth_method="oauth2").allowed
+
+    def test_yaml_default_require_tls_defaults_true(self):
+        policy = McpAuthPolicy.from_yaml("""
+mcp_auth_policy:
+  default_allowed_methods: [oauth2]
+""")
+        result = policy.check("unregistered", auth_method="oauth2", url="http://mcp.internal/tools")
+        assert not result.allowed
+
+    def test_yaml_default_require_tls_false_disables_the_floor(self):
+        policy = McpAuthPolicy.from_yaml("""
+mcp_auth_policy:
+  default_allowed_methods: [oauth2]
+  default_require_tls: false
+""")
+        result = policy.check("legacy-server", auth_method="oauth2", url="http://mcp.internal/tools")
+        assert result.allowed

--- a/docs/specs/MCP-SECURITY-GATEWAY-1.0.md
+++ b/docs/specs/MCP-SECURITY-GATEWAY-1.0.md
@@ -928,6 +928,7 @@ An auth check result MUST contain:
 | --- | --- | --- |
 | `default_allowed_methods` | `["oauth2", "mtls", "bearer"]` | Must be subset of VALID_AUTH_METHODS |
 | `deny_none` | `true` | When true, `none` is always rejected |
+| `default_require_tls` | `true` | Applies the same TLS-scheme gate as a registered `McpServerEntry` to servers with no allowlist entry; set `false` to keep the pre-fix behavior for a deployment that depends on it |
 
 **[Default Implementation]**
 
@@ -946,7 +947,10 @@ The `check(server_name, auth_method, url="")` method MUST evaluate:
 5. **TLS version check:** If the URL uses TLS, verify the minimum
    TLS version requirement is met.
 6. **Default check:** If no per-server entry exists, check against
-   `default_allowed_methods`.
+   `default_allowed_methods`. If `default_require_tls` is true and a
+   URL is supplied, apply the same TLS-scheme gate as step 4 before
+   allowing; an omitted/empty URL is not gated, matching step 4's
+   behavior for that case.
 
 **[Pure Specification]**
 
@@ -962,6 +966,7 @@ mcp_auth_policy:
     - oauth2
     - mtls
     - bearer
+  default_require_tls: true  # set false only for a deployment that needs the pre-fix behavior
   servers:
     - name: "example-server"
       url: "https://mcp.example.com"


### PR DESCRIPTION
Fixes #3814.

## What changed
`McpAuthPolicy.check()` in `agent_os/mcp_auth_enforcement.py` now applies the same TLS-scheme gate to the "fall back to default policy" branch (unregistered server names) that already exists for the per-server allowlist branch (registered entries).

Added a `default_require_tls: bool = True` constructor option (and matching `from_yaml` key) so this floor can be explicitly disabled if a deployment relies on the old behavior for unregistered servers.

## Why
As filed in #3814: when `server_name` has no entry in the allowlist, `check()` fell straight through to the default-allowlist path with **no TLS check at all** — `require_tls` semantics only existed for registered entries. A typo'd or newly-added-but-not-yet-registered MCP server name silently got weaker transport guarantees than a registered one, even when a plain-`http://` URL was supplied.

The fix mirrors the registered-entry gate's own constraint: the check only runs when a URL is actually supplied (`if self._default_require_tls and url:`), so the S10.12 spec behavior — an omitted/empty URL stays allowed — is preserved for both paths.

## How I tested
- Added 3 regression tests: unregistered server + `http://` URL is now rejected, unregistered server + `https://` URL is allowed, and the floor can be opted out via `default_require_tls=False`.
- Ran the full `test_mcp_auth_enforcement.py` suite: 20/20 passed (17 pre-existing + 3 new), confirming no existing behavior regressed — in particular the tests that call `check()` with no `url` argument at all still pass, since the TLS check is skipped when `url` is falsy.
- Checked other call sites of `McpAuthPolicy(...)` in the repo (`test_spec_mcp_gateway_conformance.py`) — all use keyword arguments, so the new constructor parameter doesn't shift anything positionally.
- Ran `ruff check` on both changed files; the only findings are pre-existing issues unrelated to this change (an `from_yaml` type-annotation style nit and an unsorted import block already present before this PR).