### PR TITLE
Loosen serde/serde_json/thiserror workspace pins to compatible ranges

### DIFF
--- a/agent-governance-rust/Cargo.toml
+++ b/agent-governance-rust/Cargo.toml
@@ -24,9 +24,9 @@ opentelemetry = { version = "=0.32.0", default-features = false, features = ["tr
 rand = "=0.8.6"
 regex = "=1.13.1"
 regorus = { version = "=0.11.0", default-features = false, features = ["regex"] }
-serde = { version = "=1.0.229", features = ["derive"] }
-serde_json = "=1.0.151"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
 serde_yaml = "=0.9.34"
 sha2 = "=0.10.9"
-thiserror = "=2.0.19"
+thiserror = "2.0.19"
 tempfile = "=3.27.0"


### PR DESCRIPTION
## Summary
`agent-governance-rust/Cargo.toml`'s `[workspace.dependencies]` exact-pins every dependency (`"=x.y.z"`), including `serde`, `serde_json`, and `thiserror`. That's understandable as a reproducibility policy for this workspace's own builds, but for a *published library* crate (`agentmesh`/`agentmesh-mcp`) it has a real downstream cost: it forces every consumer's own `Cargo.lock` to match these exact patch versions, so the moment anything else in their dependency graph needs a newer patch release of `serde`/`serde_json`/`thiserror`, the two requirements become permanently unsatisfiable together — no version of `agentmesh` fixes it, since every release re-exact-pins to whatever was current at publish time.

Concretely: [PromptExecution/ledgrrr](https://github.com/PromptExecution/ledgrrr) needed to add the [`scxml`](https://crates.io/crates/scxml) crate (`serde >=1.0.229`, `thiserror >=2.0.19`) alongside `agentmesh` 4.0.0 (which exact-pinned `serde =1.0.228`, `thiserror =2.0.18` at that release) and hit an unresolvable `cargo` conflict. We worked around it in the meantime with a locally patched vendor copy of `agentmesh`/`agentmesh-mcp` (only these two requirements loosened) — see [ledgrrr#214](https://github.com/PromptExecution/ledgrrr/pull/214) for the full context. That's meant to be temporary; this PR is the actual fix.

This PR loosens just those three (the crates most commonly required elsewhere in a dependent's graph) to standard caret ranges. It doesn't touch any of the other exact pins (`cedar-policy`, `ed25519-dalek`, `rand`, etc.) — those are more plausibly intentional for this toolkit's security-sensitive surface, and out of scope for what's actually causing downstream breakage.

## Test plan
- `cargo check --workspace` in `agent-governance-rust/` — builds clean, same resolved versions as before (only the requirement syntax changed, not the locked versions).