### PR TITLE
fix(agent-os): redact secrets glued to a following suffix

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -57,6 +57,16 @@ class CredentialRedactor:
     # word character, so ``_sk-`` has no boundary and the secret would be missed;
     # ``(?<![A-Za-z0-9])`` treats ``_`` (and ``-``, ``/``, ``.``, whitespace) as a
     # valid left edge while still not matching inside an alphanumeric word.
+    #
+    # The same problem exists on the right edge for a pattern whose value class
+    # excludes ``_``: AWS access key, GitHub token, Google API key and Stripe
+    # secret key all have a fixed length or a value class without ``_``, so a
+    # trailing ``\b`` after a suffix like ``_old`` finds no shorter match to
+    # back off to and the whole pattern fails, leaving a valid secret fully
+    # unredacted rather than truncated. Those four use the mirror assertion
+    # ``(?![A-Za-z0-9])`` instead. Patterns whose value class already includes
+    # ``_`` (OpenAI, Bearer, JWT) do not need this: the class consumes the
+    # suffix on its own and a trailing ``\b`` is harmless there.
     PATTERNS: tuple[CredentialPattern, ...] = (
         CredentialPattern(
             name="OpenAI API key",
@@ -65,12 +75,12 @@ class CredentialRedactor:
         CredentialPattern(
             name="GitHub token",
             pattern=re.compile(
-                r"(?<![A-Za-z0-9])(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})(?![A-Za-z0-9_])"
+                r"(?<![A-Za-z0-9])(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})(?![A-Za-z0-9])"
             ),
         ),
         CredentialPattern(
             name="AWS access key",
-            pattern=re.compile(r"(?<![A-Za-z0-9])AKIA[A-Z0-9]{16}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])AKIA[A-Z0-9]{16}(?![A-Za-z0-9])"),
         ),
         CredentialPattern(
             # The 40-char base64 secret value has no distinctive prefix, so it is
@@ -120,7 +130,8 @@ class CredentialRedactor:
         CredentialPattern(
             name="Basic auth secret",
             pattern=re.compile(
-                r"(?i)(?:\bBasic\s+[A-Za-z0-9+/=]{8,}\b|\b[a-z][a-z0-9+.-]*://[^/\s:@]+:[^@\s/]+@)"
+                r"(?i)(?:(?<![A-Za-z0-9])Basic\s+[A-Za-z0-9+/=]{8,}(?![A-Za-z0-9+/=])"
+                r"|(?<![A-Za-z0-9])[a-z][a-z0-9+.-]*://[^/\s:@]+:[^@\s/]+@)"
             ),
         ),
         CredentialPattern(
@@ -139,11 +150,11 @@ class CredentialRedactor:
         ),
         CredentialPattern(
             name="Google API key",
-            pattern=re.compile(r"(?<![A-Za-z0-9])AIza[0-9A-Za-z_\-]{35}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])AIza[0-9A-Za-z_\-]{35}(?![A-Za-z0-9])"),
         ),
         CredentialPattern(
             name="Stripe secret key",
-            pattern=re.compile(r"(?<![A-Za-z0-9])(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}(?![A-Za-z0-9])"),
         ),
         CredentialPattern(
             name="Generic API secret",

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 """Tests for credential redaction helpers."""
 
+# cspell:ignore AKIAIOSFODNN Nlcjpw
+
 from __future__ import annotations
 
 import time
@@ -19,6 +21,12 @@ def _fake_github_token(prefix: str) -> str:
 # appears in source (avoids secret-scanner false positives on a test value).
 _FAKE_GOOGLE_KEY = "AIza" + "SyD1234567890abcdefghijklmnopqrstuv"
 
+# AWS's own documentation example access key ID — deterministic and clearly fake.
+_FAKE_AWS_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
+
+# base64("user:pass123"), used only as a Basic auth credential value fixture.
+_FAKE_BASIC_AUTH_VALUE = "dXNlcjpwYXNzMTIz"
+
 
 def _fake_pem_block(label: str) -> str:
     return (
@@ -34,7 +42,7 @@ def _fake_pem_block(label: str) -> str:
     [
         ("key=sk-test_abcdefghijklmnopqrstuvwxyz", "OpenAI API key"),
         ("token=ghp_FAKEFORTESTING000000000000000000", "GitHub token"),
-        ("aws=AKIAIOSFODNN7EXAMPLE", "AWS access key"),
+        (f"aws={_FAKE_AWS_ACCESS_KEY}", "AWS access key"),
         ("AccountKey=abc123def456ghi789jkl012mno345pqr678stu901vw==", "Azure key"),
         (
             "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature",
@@ -151,7 +159,6 @@ def test_redacts_supported_github_token_prefixes(token: str):
     "text",
     [
         f"x{_fake_github_token('ghp')}",
-        f"{_fake_github_token('ghs')}_",
         "gho_short",
         "github_pat_short",
         "notgithub_pat_FAKE_FOR_TESTING_0000000000000000000000",
@@ -184,6 +191,25 @@ def test_private_key_pattern_handles_adversarial_input_quickly():
     elapsed = time.perf_counter() - start
 
     assert redacted == text
+    assert elapsed < 1.0
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "AKIA" + "A" * 100_000,
+        "gh" + "p_" + "a" * 100_000,
+        "AIza" + "A" * 100_000,
+        "sk_live_" + "a" * 100_000,
+    ],
+)
+def test_trailing_lookahead_patterns_handle_adversarial_input_quickly(text: str):
+    # The new trailing lookahead is a single fixed-width check, not a repeated
+    # class, so it does not change the linear-time behavior of these patterns.
+    start = time.perf_counter()
+    CredentialRedactor.redact(text)
+    elapsed = time.perf_counter() - start
+
     assert elapsed < 1.0
 
 
@@ -317,13 +343,68 @@ def test_detection_and_redaction_agree_on_adjacent_anchored_secrets():
         "svc_" + _FAKE_GOOGLE_KEY,
         "env_sk_live_FakeTestKey0000",
         "db_password=Hunter2xyz",
+        f"auth_Basic {_FAKE_BASIC_AUTH_VALUE}",
+        "url_https://user:pass123@example.com/resource",
     ],
 )
 def test_detects_secret_glued_to_preceding_word_character(text: str):
     # Regression: a leading \b treats "_" as a word character, so a secret glued
     # directly after "_" was missed. The (?<![A-Za-z0-9]) anchor detects it.
+    # The Basic auth secret pattern kept a plain \b on its left edge after
+    # every other prefix-anchored pattern had already moved to the lookbehind,
+    # so both of its branches were still missing this case until now.
     assert CredentialRedactor.contains_credentials(text) is True
     assert REDACTED_PLACEHOLDER in CredentialRedactor.redact(text)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_type"),
+    [
+        (f"{_FAKE_AWS_ACCESS_KEY}_old", "AWS access key"),
+        (f"{_fake_github_token('ghp')}_old", "GitHub token"),
+        (f"{_fake_github_token('ghs')}_deprecated", "GitHub token"),
+        (f"{_fake_github_token('gho')}_backup", "GitHub token"),
+        (f"{_fake_github_token('ghu')}_rotated", "GitHub token"),
+        (f"{_fake_github_token('ghr')}_v2", "GitHub token"),
+        (f"{_FAKE_GOOGLE_KEY}_old", "Google API key"),
+        ("stripe=sk_live_FakeTestKey0000_rotated", "Stripe secret key"),
+        (f"Basic {_FAKE_BASIC_AUTH_VALUE}_old", "Basic auth secret"),
+    ],
+)
+def test_redacts_secret_glued_to_a_following_word_character(text: str, expected_type: str):
+    # Regression: AWS access key, GitHub token, Google API key and Stripe secret
+    # key either have a fixed length or a value class that excludes "_". A
+    # trailing \b (or, for GitHub, a lookahead that still excluded "_") after
+    # one of those finds no shorter match to back off to when the secret is
+    # followed by an annotation like "_old", so the entire pattern failed and
+    # the complete, valid secret passed through unredacted. Basic auth secret
+    # had the same right-edge gap once its left edge was anchored correctly.
+    redacted = CredentialRedactor.redact(text)
+
+    assert REDACTED_PLACEHOLDER in redacted
+    assert expected_type in CredentialRedactor.detect_credential_types(text)
+    assert CredentialRedactor.contains_credentials(text) is True
+    # The suffix is annotation, not part of the secret, and must survive.
+    assert text.rsplit("_", 1)[-1] in redacted
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        f"{_FAKE_AWS_ACCESS_KEY}X",
+        f"{_FAKE_GOOGLE_KEY}9",
+        "sk_live_short",
+        f"Basic {_FAKE_BASIC_AUTH_VALUE[:6]}",
+        "https://example.com/resource",
+    ],
+)
+def test_trailing_anchor_does_not_widen_the_match(text: str):
+    # The mirror assertion on the right edge is exactly as strict about what
+    # may follow as the fixed length or value class already was: one more
+    # alphanumeric character after a fixed-length key is a longer, different
+    # token, not the same key with an annotation, and must stay unmatched.
+    assert CredentialRedactor.redact(text) == text
+    assert CredentialRedactor.contains_credentials(text) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related Issue
Fixes #3494

## Timeline
None

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
**Core & runtime:**
- [ ] agent-governance-toolkit-core
- [ ] agent-primitives
- [x] agent-os
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-compliance

## Testing

### Unit Testing
Added `test_redacts_secret_glued_to_a_following_word_character`, covering AWS access key, all five GitHub token prefixes, Google API key, Stripe secret key and Basic auth secret with a suffix such as `_old` or `_rotated` glued directly to the secret. Added `test_trailing_anchor_does_not_widen_the_match` to confirm the new lookahead does not loosen the boundary: one extra character after a fixed length key, a Stripe key under the length floor, a short Basic value and a Basic auth URL with no credentials all still fail to match. Added two glued left edge cases (`auth_Basic ...` and `url_https://user:pass@...`) to the existing `test_detects_secret_glued_to_preceding_word_character` parametrization, since Basic auth secret still had the left edge `\b` bug that every other prefix anchored pattern had already moved away from. Removed one case from `test_github_token_boundaries_and_lengths_avoid_false_positives` that encoded the bug itself as expected behavior (a GitHub token followed by a bare underscore was asserted to produce no match at all). Added `test_trailing_lookahead_patterns_handle_adversarial_input_quickly` to confirm the new lookahead does not introduce backtracking on 100k character adversarial input.

`pytest agent-governance-python/agent-os/tests/test_credential_redactor.py`: 93 passed. Reverting only the source change while keeping the new tests: 11 of those fail, confirming they exercise the fix rather than just describing it.

### Manual Testing
Ran `AKIAIOSFODNN7EXAMPLE_old` through `CredentialRedactor.redact` and `contains_credentials` directly before and after the change: before, the input passed through completely unredacted and detection reported nothing; after, it redacts to `[REDACTED]_old` and detection reports `AWS access key`. Repeated for the GitHub, Google, Stripe and Basic auth cases described in the linked issue.

## Checklist
- [x] I have linked a related issue above, or completed "Problem & Solution", "Impact on Your Work", and "Alternatives Considered"
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects:** none. Note for reviewers: issue #3494 previously had a fix proposed in #3495, which went through review and was closed on 2026-08-05 for a reason unrelated to the code ("this repository is not accepting submissions from this account"). This PR reaches the same diagnosis independently by reading the current pattern table in `credential_redactor.py` against the issue's own description, and was not copied from #3495.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

An AI coding assistant running in my terminal was used for the regex analysis, the test authoring and this description. I reviewed, ran and verified every change before opening this PR.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License
