### PR TITLE
fix: launch Claude Code hooks with Node directly

### DIFF
--- a/agent-governance-claude-code/hooks/hooks.json
+++ b/agent-governance-claude-code/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agt-node",
+            "command": "node",
             "args": [
               "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.mjs"
             ],
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agt-node",
+            "command": "node",
             "args": [
               "${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit.mjs"
             ],
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agt-node",
+            "command": "node",
             "args": [
               "${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use.mjs"
             ],

--- a/agent-governance-claude-code/test/hooks.test.mjs
+++ b/agent-governance-claude-code/test/hooks.test.mjs
@@ -2,12 +2,30 @@
 // Licensed under the MIT License.
 
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+
+test("hooks manifest invokes Node directly in exec form", async () => {
+  const hooksPath = fileURLToPath(new URL("../hooks/hooks.json", import.meta.url));
+  const manifest = JSON.parse(await readFile(hooksPath, "utf8"));
+  const hookScripts = {
+    PreToolUse: "pre-tool-use.mjs",
+    SessionStart: "session-start.mjs",
+    UserPromptSubmit: "user-prompt-submit.mjs",
+  };
+
+  for (const [event, script] of Object.entries(hookScripts)) {
+    const [matcher] = manifest.hooks[event];
+    const [hook] = matcher.hooks;
+
+    assert.equal(hook.command, "node");
+    assert.deepEqual(hook.args, ["${CLAUDE_PLUGIN_ROOT}/hooks/" + script]);
+  }
+});
 
 test("pre-tool-use hook emits a deny decision for dangerous shell bootstraps", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-claude-hook-"));


### PR DESCRIPTION
## Summary

Launch Claude Code hooks with the `node` executable directly so exec-form hook registration works on Windows as well as POSIX systems.

## Related Issue

Fixes #3831

## Problem & Solution

Claude Code launched the plugin hooks in exec form, but their command targeted the extensionless POSIX `bin/agt-node` shell wrapper. Windows cannot execute that shell script directly, so `SessionStart`, `UserPromptSubmit`, and `PreToolUse` silently never ran.

Each hook now invokes `node` directly and retains the hook script as its argument. This preserves the existing behavior on POSIX while using an executable command that Windows can start in exec form.

## Timeline

None.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Package(s) Affected

**CLI plugins:**
- [x] agent-governance CLI plugins (copilot-cli / claude-code / opencode / antigravity-cli)

## Changes

| File | What changed |
|------|--------------|
| `agent-governance-claude-code/hooks/hooks.json` | Changed all three Claude hook launch commands from the POSIX shell wrapper to `node`. |
| `agent-governance-claude-code/test/hooks.test.mjs` | Added a regression test that asserts every hook uses exec-compatible `node` invocation and preserves its expected script argument. |

## Testing

`npm run check` in `agent-governance-claude-code/` (18 tests passed), including the new manifest regression test and existing policy, audit, MCP, and marketplace checks.

### Unit Testing

The regression test covers `SessionStart`, `UserPromptSubmit`, and `PreToolUse` manifest entries, preventing a return to the non-executable wrapper command.

### Manual Testing

N/A; the manifest contract and hook behavior are covered by the package test suite.

## Checklist

- [x] I have linked a related issue above, or completed "Problem & Solution", "Impact on Your Work", and "Alternatives Considered"
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (via `npm run check`)
- [x] I have updated documentation as needed (not needed for this internal launch-wiring fix)

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution

**Prior art / related projects** (if any):

None.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change

GitHub Copilot assisted with the implementation and regression test; the changes and test results were reviewed before submission.
