### PR TITLE
fix: redact secrets with underscore suffixes

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -57,6 +57,9 @@ class CredentialRedactor:
     # word character, so ``_sk-`` has no boundary and the secret would be missed;
     # ``(?<![A-Za-z0-9])`` treats ``_`` (and ``-``, ``/``, ``.``, whitespace) as a
     # valid left edge while still not matching inside an alphanumeric word.
+    # Matching patterns use the mirrored ``(?![A-Za-z0-9])`` assertion at their
+    # right edge when a value class excludes ``_``. This preserves suffixes such
+    # as ``_old`` without rejecting the complete secret before them.
     PATTERNS: tuple[CredentialPattern, ...] = (
         CredentialPattern(
             name="OpenAI API key",
@@ -70,7 +73,7 @@ class CredentialRedactor:
         ),
         CredentialPattern(
             name="AWS access key",
-            pattern=re.compile(r"(?<![A-Za-z0-9])AKIA[A-Z0-9]{16}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])AKIA[A-Z0-9]{16}(?![A-Za-z0-9])"),
         ),
         CredentialPattern(
             # The 40-char base64 secret value has no distinctive prefix, so it is
@@ -120,7 +123,8 @@ class CredentialRedactor:
         CredentialPattern(
             name="Basic auth secret",
             pattern=re.compile(
-                r"(?i)(?:\bBasic\s+[A-Za-z0-9+/=]{8,}\b|\b[a-z][a-z0-9+.-]*://[^/\s:@]+:[^@\s/]+@)"
+                r"(?i)(?:(?<![A-Za-z0-9])Basic\s+[A-Za-z0-9+/=]{8,}(?![A-Za-z0-9+/=])|"
+                r"(?<![A-Za-z0-9])[a-z][a-z0-9+.-]*://[^/\s:@]+:[^@\s/]+@)"
             ),
         ),
         CredentialPattern(
@@ -139,11 +143,13 @@ class CredentialRedactor:
         ),
         CredentialPattern(
             name="Google API key",
-            pattern=re.compile(r"(?<![A-Za-z0-9])AIza[0-9A-Za-z_\-]{35}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])AIza[0-9A-Za-z_\-]{35}(?![A-Za-z0-9])"),
         ),
         CredentialPattern(
             name="Stripe secret key",
-            pattern=re.compile(r"(?<![A-Za-z0-9])(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}\b"),
+            pattern=re.compile(
+                r"(?<![A-Za-z0-9])(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}(?![A-Za-z0-9])"
+            ),
         ),
         CredentialPattern(
             name="Generic API secret",

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -8,7 +8,7 @@ import time
 
 import pytest
 
-from agent_os.credential_redactor import CredentialRedactor, REDACTED_PLACEHOLDER
+from agent_os.credential_redactor import REDACTED_PLACEHOLDER, CredentialRedactor
 
 
 def _fake_github_token(prefix: str) -> str:
@@ -324,6 +324,73 @@ def test_detects_secret_glued_to_preceding_word_character(text: str):
     # directly after "_" was missed. The (?<![A-Za-z0-9]) anchor detects it.
     assert CredentialRedactor.contains_credentials(text) is True
     assert REDACTED_PLACEHOLDER in CredentialRedactor.redact(text)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_redacted", "expected_type"),
+    [
+        ("AKIAIOSFODNN7EXAMPLE_old", "[REDACTED]_old", "AWS access key"),
+        (
+            "AWS_ACCESS_KEY_ID_OLD=AKIAIOSFODNN7EXAMPLE_deprecated",
+            "AWS_ACCESS_KEY_ID_OLD=[REDACTED]_deprecated",
+            "AWS access key",
+        ),
+        (
+            '{"AKIAIOSFODNN7EXAMPLE_backup": "unused"}',
+            '{"[REDACTED]_backup": "unused"}',
+            "AWS access key",
+        ),
+        (
+            f"rotate {_FAKE_GOOGLE_KEY}_v2 today",
+            "rotate [REDACTED]_v2 today",
+            "Google API key",
+        ),
+        (
+            "stripe=sk_live_FakeTestKey0000_rotated",
+            "stripe=[REDACTED]_rotated",
+            "Stripe secret key",
+        ),
+        (
+            "auth_Basic YWxhZGRpbjpvcGVuc2VzYW1l",
+            "auth_[REDACTED]",
+            "Basic auth secret",
+        ),
+        (
+            "url_https://alice:password@example.com/resource",
+            "url_[REDACTED]example.com/resource",
+            "Basic auth secret",
+        ),
+    ],
+)
+def test_redacts_complete_secret_before_glued_suffix(
+    text: str, expected_redacted: str, expected_type: str
+):
+    assert CredentialRedactor.redact(text) == expected_redacted
+    assert expected_type in CredentialRedactor.detect_credential_types(text)
+    assert CredentialRedactor.contains_credentials(text) is True
+
+
+def test_redacts_basic_auth_padding_completely():
+    text = "auth_Basic YWJjZGVmZ2hpaw=="
+
+    assert CredentialRedactor.redact(text) == "auth_[REDACTED]"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "xAKIAIOSFODNN7EXAMPLE_old",
+        "AKIAIOSFODNN7EXAMPLEX",
+        f"x{_FAKE_GOOGLE_KEY}",
+        f"{_FAKE_GOOGLE_KEY}X",
+        "sk_live_short",
+        "auth_Basic short",
+        "url_https://example.com/path",
+    ],
+)
+def test_secret_suffix_anchors_reject_alphanumeric_overruns_and_incomplete_values(text: str):
+    assert CredentialRedactor.contains_credentials(text) is False
+    assert CredentialRedactor.redact(text) == text
 
 
 @pytest.mark.parametrize(

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -326,6 +326,7 @@ def test_detects_secret_glued_to_preceding_word_character(text: str):
     assert REDACTED_PLACEHOLDER in CredentialRedactor.redact(text)
 
 
+# cspell:ignore AKIAIOSFODNN Rpbjpvc hpaw EXAMPLEX
 @pytest.mark.parametrize(
     ("text", "expected_redacted", "expected_type"),
     [


### PR DESCRIPTION
## Summary

Redacts complete credential values when an underscore-delimited annotation, such as `_old` or `_rotated`, follows the secret.

Fixes #3494.

## Problem

Trailing word-boundary assertions rejected fixed-length AWS and Google keys, plus Stripe keys, when a suffix was appended. Basic authentication patterns also used word-boundary anchors that missed underscore-prefixed forms.

## Changes

| File | What changed |
|---|---|
| `agent-governance-python/agent-os/src/agent_os/credential_redactor.py` | Uses mirrored alphanumeric lookarounds for affected credential patterns and corrects Basic-auth anchors. |
| `agent-governance-python/agent-os/tests/test_credential_redactor.py` | Adds suffix, Base64-padding, and false-positive regression cases. |

## Testing

`python -m pytest tests\test_credential_redactor.py` — 89 passed

`python -m ruff check src\agent_os\credential_redactor.py tests\test_credential_redactor.py` — passed