### PR TITLE
feat(typescript): map WebMCP tool calls to FrameworkInvocation

### DIFF
--- a/agent-governance-typescript/README.md
+++ b/agent-governance-typescript/README.md
@@ -349,6 +349,35 @@ The adapter is now **identity-bound** to the `AgentMeshClient` you construct it 
 
 **Migration guidance:** if you previously reused one `GenericFrameworkAdapter` across multiple runtime identities and passed per-call `agentId` values, create a separate `AgentMeshClient`/`GenericFrameworkAdapter` pair for each real agent identity instead of relying on caller-asserted IDs.
 
+### `toFrameworkInvocation` (WebMCP)
+
+[WebMCP](https://github.com/webmachinelearning/webmcp) lets a web page register client-side tools for a browser agent via `document.modelContext.registerTool()`. A tool's `execute()` callback runs in the page itself and typically calls back into the site's own backend to do its real work. `toFrameworkInvocation()` maps that backend call onto a `FrameworkInvocation` so it can be governed with the same `GenericFrameworkAdapter` used for any other framework integration — this does not run governance inside the browser page.
+
+```typescript
+import {
+  AgentMeshClient,
+  GenericFrameworkAdapter,
+  toFrameworkInvocation,
+} from '@microsoft/agent-governance-sdk';
+
+// Backend handler for the WebMCP tool's execute() callback, e.g. POST /api/draft
+const client = AgentMeshClient.create('site-webmcp-agent', {
+  policyRules: [{ action: 'webmcp.email.createDraft', effect: 'allow' }],
+});
+const adapter = new GenericFrameworkAdapter(client);
+
+const invocation = toFrameworkInvocation(
+  { name: 'email.createDraft', annotations: { readOnlyHint: false } },
+  { to: 'someone@example.com' },
+);
+
+const result = await adapter.run(invocation, async () => createDraft());
+```
+
+Only the two annotations merged into the WebMCP spec today (`readOnlyHint`, `untrustedContentHint`) are read explicitly; any other annotation (including proposed-but-unmerged hints like `consequentialHint`, [webmachinelearning/webmcp#217](https://github.com/webmachinelearning/webmcp/issues/217)) is passed through under `attributes.webmcpAnnotations`, namespaced so a page-supplied annotation name can never shadow `attributes.assertedAgentOrigin` in the audit trace.
+
+**This namespacing protects audit-trail integrity only — it is not an origin-verification mechanism, and policy conditions never see it.** `attributes` are attached to the trace span, but policy decisions are made against `action` and `input` alone. Since `input` is the tool call's own page-controlled arguments, a page can put any key it wants there — including something shaped like `assertedAgentOrigin` — and a policy condition keyed on that field would match the forged value regardless of what this module does with `attributes`. If you need to gate governance on the calling page's origin, that verification must happen in your own backend code *before* calling `toFrameworkInvocation`/`adapter.run()` — WebMCP does not yet define a verified client/origin binding ([webmachinelearning/webmcp#96](https://github.com/webmachinelearning/webmcp/issues/96), [#105](https://github.com/webmachinelearning/webmcp/issues/105)), so `client.agentOrigin` is only ever a best-effort hint. See `examples/webmcp-tool-governance.ts` for a full example.
+
 ## Development
 
 ```bash

--- a/agent-governance-typescript/examples/webmcp-tool-governance.ts
+++ b/agent-governance-typescript/examples/webmcp-tool-governance.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/**
+ * Example: governing the backend action behind a WebMCP tool call.
+ *
+ * Run with: `npx ts-node examples/webmcp-tool-governance.ts`
+ *
+ * WebMCP (https://github.com/webmachinelearning/webmcp) lets a page
+ * register a client-side tool for a browser agent to call:
+ *
+ *   await document.modelContext.registerTool({
+ *     name: 'email.createDraft',
+ *     annotations: { readOnlyHint: false },
+ *     inputSchema: { ... },
+ *     async execute(input) {
+ *       // The page's own script calls back into its backend to do the
+ *       // real work (webmachinelearning/webmcp#105, "Server-Side
+ *       // Verification"). That backend call is what this example governs
+ *       // -- AGT does not run inside the browser page itself.
+ *       return fetch('/api/draft', { method: 'POST', body: JSON.stringify(input) });
+ *     },
+ *   });
+ *
+ * The snippet below is the backend side of `POST /api/draft`: it maps the
+ * incoming WebMCP tool call onto a `FrameworkInvocation` and runs it
+ * through the same `GenericFrameworkAdapter` used for any other framework
+ * integration, so the call is policy-checked, trust-scored, and
+ * audit-logged before the handler executes.
+ */
+
+import { AgentMeshClient } from '../src/client';
+import { GenericFrameworkAdapter } from '../src/framework-adapter';
+import { toFrameworkInvocation } from '../src/webmcp';
+
+async function handleCreateDraftRequest(input: { to: string; body: string }): Promise<unknown> {
+  const client = AgentMeshClient.create('site-webmcp-agent', {
+    policyRules: [
+      { action: 'webmcp.email.createDraft', effect: 'allow' },
+      { action: '*', effect: 'deny' },
+    ],
+  });
+  const adapter = new GenericFrameworkAdapter(client);
+
+  const invocation = toFrameworkInvocation(
+    { name: 'email.createDraft', annotations: { readOnlyHint: false } },
+    input,
+  );
+
+  const result = await adapter.run(invocation, async () => {
+    // The tool's actual side effect, only reached if governance allows it.
+    return { draftId: 'draft-1', to: input.to };
+  });
+
+  if (!result.allowed) {
+    throw new Error(`WebMCP tool call denied: ${result.reason}`);
+  }
+
+  return result.output;
+}
+
+async function main(): Promise<void> {
+  const output = await handleCreateDraftRequest({ to: 'someone@example.com', body: 'Hi!' });
+  console.log('draft created:', output);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+export { handleCreateDraftRequest };

--- a/agent-governance-typescript/src/index.ts
+++ b/agent-governance-typescript/src/index.ts
@@ -25,6 +25,8 @@ export {
 } from './metrics';
 export { McpSecurityScanner, McpThreatType } from './mcp';
 export type { McpScanResult, McpThreat, McpToolDefinition } from './mcp';
+export { toFrameworkInvocation } from './webmcp';
+export type { WebMcpToolLike, WebMcpClientLike, WebMcpInvocationOptions } from './webmcp';
 export { LifecycleManager, LifecycleState } from './lifecycle';
 export type { LifecycleEvent } from './lifecycle';
 export { ShadowDiscovery } from './discovery';

--- a/agent-governance-typescript/src/webmcp.ts
+++ b/agent-governance-typescript/src/webmcp.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// ── WebMCP invocation mapping ──
+//
+// WebMCP (https://github.com/webmachinelearning/webmcp) lets a web page
+// register client-side tools via `document.modelContext.registerTool()`.
+// The `execute()` callback for such a tool runs inside the page's own
+// script and typically performs its real work by calling back into the
+// site's own backend (see webmachinelearning/webmcp#105, "Server-Side
+// Verification"). That backend call is the seam where AGT governance
+// applies: `toFrameworkInvocation()` shapes a WebMCP tool call into a
+// `FrameworkInvocation` so it can be run through the existing
+// `GenericFrameworkAdapter`, the same way any other framework tool call
+// is governed. This module does not attempt to run policy evaluation
+// inside the browser page itself.
+//
+// Only the two annotations that are merged into the WebMCP spec today
+// (`readOnlyHint`, `untrustedContentHint`) are read explicitly. Anything
+// else on `annotations` is passed through under `attributes.webmcpAnnotations`
+// so callers can act on proposed-but-unmerged hints (e.g. `consequentialHint`,
+// webmachinelearning/webmcp#217) without this module hard-coding a shape
+// that hasn't landed yet. It is namespaced rather than flattened onto
+// `attributes` directly so that a page-supplied annotation name can never
+// collide with (and shadow) `attributes.assertedAgentOrigin` in the audit
+// trace -- annotations come from the same untrusted page as the tool call
+// itself.
+//
+// IMPORTANT -- this namespacing is an audit-trail-integrity measure only,
+// not an origin-verification mechanism, and it does not protect policy
+// evaluation: `GenericFrameworkAdapter.beginInvocation()` passes
+// `attributes` only into the trace span (see framework-adapter.ts); policy
+// conditions are evaluated by `AgentMeshClient.executeWithGovernance()`
+// against `action` and `input` alone (client.ts's `policy.evaluate(action,
+// input)`), and `input` is the tool call's own page-controlled arguments
+// (the second parameter to `toFrameworkInvocation`). A page can put any key
+// it wants in `input`, including e.g. `assertedAgentOrigin`, and a policy
+// condition that keys on that field would match the forged value --
+// `attributes.assertedAgentOrigin` set here is never consulted. Do not
+// write policy conditions that trust identity-shaped fields inside
+// `input`. If a caller needs to gate on the page's origin, that
+// verification must happen in the embedding application *before* calling
+// `toFrameworkInvocation`/`adapter.run()` at all (e.g. failing closed and
+// never reaching this module), since WebMCP itself does not yet define a
+// verified client/origin binding (webmachinelearning/webmcp#96, #105) --
+// `client.agentOrigin` here is a best-effort hint, not something this
+// module can verify.
+
+import { FrameworkInvocation } from './framework-adapter';
+
+/** Minimal shape of a WebMCP `ModelContextTool`, as much as this module needs. */
+export interface WebMcpToolLike {
+  name: string;
+  annotations?: {
+    readOnlyHint?: boolean;
+    untrustedContentHint?: boolean;
+    [extra: string]: unknown;
+  };
+}
+
+/**
+ * Minimal shape of a WebMCP `ModelContextClient`. Identity fields here are
+ * proposals, not merged spec (webmachinelearning/webmcp#96, #105) — treat
+ * any of them as best-effort hints, never as verified identity.
+ */
+export interface WebMcpClientLike {
+  agentOrigin?: string;
+}
+
+export interface WebMcpInvocationOptions {
+  /** Prefix used for the resulting governance action name. Defaults to "webmcp". */
+  actionPrefix?: string;
+}
+
+/**
+ * Maps a WebMCP tool invocation into a `FrameworkInvocation` suitable for
+ * `GenericFrameworkAdapter.run()` / `beginInvocation()`.
+ */
+export function toFrameworkInvocation(
+  tool: WebMcpToolLike,
+  input: Record<string, unknown> = {},
+  client?: WebMcpClientLike,
+  options: WebMcpInvocationOptions = {},
+): FrameworkInvocation {
+  const actionPrefix = options.actionPrefix ?? 'webmcp';
+
+  // Read tool.name exactly once: a getter could otherwise return different
+  // values on successive reads, letting the `name` and `action` fields on
+  // the resulting invocation disagree. Reject anything that is not a
+  // non-empty string so a missing/malformed name (undefined, null, '', 5)
+  // can never silently become a real, policy-matchable action like
+  // `webmcp.undefined`. Also reject a literal '*' -- it would flow into
+  // the constructed action string and could be confused with the wildcard
+  // pattern semantics the policy engine itself uses (policy.ts's
+  // `matchAction`), rather than being a real tool name.
+  const name = tool.name;
+  if (typeof name !== 'string' || name.length === 0 || name.includes('*')) {
+    throw new Error(
+      `toFrameworkInvocation: tool.name must be a non-empty string without '*', got ${JSON.stringify(name)}`,
+    );
+  }
+
+  // tool.annotations and client.agentOrigin both originate from the
+  // untrusted page. Read each exactly once into a local, the same as
+  // `name` above: a getter could otherwise return a different value on
+  // each access, letting it pass the type check below and then land a
+  // different (unchecked) value in `attributes`. Type-check the snapshot
+  // explicitly rather than trusting the TypeScript interface at runtime
+  // (a plain JS caller, or a page lying through a proxy, can hand us
+  // anything): an unexpected shape here (e.g. an array/primitive for
+  // `annotations`, or a non-string `agentOrigin`) fails loudly instead of
+  // silently destructuring into `{}` or flowing a wrong-typed value into
+  // `attributes`.
+  const annotations = tool.annotations;
+  const agentOrigin = client?.agentOrigin;
+
+  if (
+    annotations !== undefined &&
+    (typeof annotations !== 'object' || annotations === null || Array.isArray(annotations))
+  ) {
+    throw new Error(
+      `toFrameworkInvocation: tool.annotations must be a plain object if provided, got ${JSON.stringify(annotations)}`,
+    );
+  }
+  if (agentOrigin !== undefined && typeof agentOrigin !== 'string') {
+    throw new Error(
+      `toFrameworkInvocation: client.agentOrigin must be a string if provided, got ${JSON.stringify(agentOrigin)}`,
+    );
+  }
+
+  const { readOnlyHint, untrustedContentHint, ...restAnnotations } = annotations ?? {};
+
+  const attributes: Record<string, unknown> = {};
+  if (readOnlyHint !== undefined) attributes.readOnlyHint = readOnlyHint;
+  if (untrustedContentHint !== undefined) attributes.untrustedContentHint = untrustedContentHint;
+  if (agentOrigin !== undefined) attributes.assertedAgentOrigin = agentOrigin;
+  if (Object.keys(restAnnotations).length > 0) attributes.webmcpAnnotations = restAnnotations;
+
+  return {
+    name,
+    kind: 'tool_call',
+    action: `${actionPrefix}.${name}`,
+    input,
+    attributes,
+  };
+}

--- a/agent-governance-typescript/tests/webmcp.test.ts
+++ b/agent-governance-typescript/tests/webmcp.test.ts
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AgentMeshClient } from '../src/client';
+import { GenericFrameworkAdapter } from '../src/framework-adapter';
+import { toFrameworkInvocation } from '../src/webmcp';
+
+describe('toFrameworkInvocation', () => {
+  it('maps a WebMCP tool call to a governed action with the default prefix', () => {
+    const invocation = toFrameworkInvocation(
+      { name: 'email.createDraft', annotations: { readOnlyHint: false } },
+      { to: 'someone@example.com' },
+    );
+
+    expect(invocation.name).toBe('email.createDraft');
+    expect(invocation.kind).toBe('tool_call');
+    expect(invocation.action).toBe('webmcp.email.createDraft');
+    expect(invocation.input).toEqual({ to: 'someone@example.com' });
+    expect(invocation.attributes).toEqual({ readOnlyHint: false });
+  });
+
+  it('supports a custom action prefix', () => {
+    const invocation = toFrameworkInvocation(
+      { name: 'search' },
+      {},
+      undefined,
+      { actionPrefix: 'easely.webmcp' },
+    );
+
+    expect(invocation.action).toBe('easely.webmcp.search');
+  });
+
+  it('passes through unmerged/proposed annotations under a dedicated namespace', () => {
+    const invocation = toFrameworkInvocation(
+      { name: 'checkout.pay', annotations: { consequentialHint: true, untrustedContentHint: false } },
+      {},
+    );
+
+    expect(invocation.attributes).toEqual({
+      untrustedContentHint: false,
+      webmcpAnnotations: { consequentialHint: true },
+    });
+  });
+
+  it('carries a best-effort agent origin without treating it as verified identity', () => {
+    const invocation = toFrameworkInvocation(
+      { name: 'checkout.pay' },
+      {},
+      { agentOrigin: 'google.com' },
+    );
+
+    expect(invocation.attributes).toEqual({ assertedAgentOrigin: 'google.com' });
+  });
+
+  it('does not let a page-supplied annotation shadow a reserved attribute name', () => {
+    const invocation = toFrameworkInvocation(
+      {
+        name: 'transfer',
+        annotations: {
+          readOnlyHint: true,
+          untrustedContentHint: true,
+          assertedAgentOrigin: 'https://trusted.example',
+        },
+      },
+      {},
+      { agentOrigin: 'google.com' },
+    );
+
+    expect(invocation.attributes).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: true,
+      assertedAgentOrigin: 'google.com',
+      webmcpAnnotations: { assertedAgentOrigin: 'https://trusted.example' },
+    });
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty string', ''],
+    ['a number', 5],
+    ['a wildcard', '*'],
+  ])('rejects a non-empty-string tool.name (%s)', (_label, badName) => {
+    expect(() =>
+      toFrameworkInvocation({ name: badName as unknown as string }, {}),
+    ).toThrow(/tool\.name must be a non-empty string(?: without '\*')?/);
+  });
+
+  it('reads tool.name once, so a getter cannot make name and action disagree', () => {
+    let reads = 0;
+    const tool = {
+      get name() {
+        reads += 1;
+        return reads === 1 ? 'checkout.pay' : 'checkout.refund';
+      },
+    };
+
+    const invocation = toFrameworkInvocation(tool, {});
+
+    expect(invocation.name).toBe('checkout.pay');
+    expect(invocation.action).toBe('webmcp.checkout.pay');
+    expect(reads).toBe(1);
+  });
+
+  it.each([
+    ['a number', 5],
+    ['a string', 'not-an-object'],
+    ['an array', ['readOnlyHint']],
+  ])('rejects a non-object tool.annotations (%s)', (_label, badAnnotations) => {
+    expect(() =>
+      toFrameworkInvocation({ name: 'checkout.pay', annotations: badAnnotations as never }, {}),
+    ).toThrow(/tool\.annotations must be a plain object/);
+  });
+
+  it('rejects a non-string client.agentOrigin', () => {
+    expect(() =>
+      toFrameworkInvocation({ name: 'checkout.pay' }, {}, { agentOrigin: 12345 as unknown as string }),
+    ).toThrow(/client\.agentOrigin must be a string/);
+  });
+
+  it('does not treat attributes.assertedAgentOrigin as a policy-visible field', async () => {
+    // Regression guard for the docstring/README fix: `attributes` (where
+    // assertedAgentOrigin lives) must never reach policy evaluation --
+    // only `action` and `input` do. A policy condition keyed on
+    // `assertedAgentOrigin` should evaluate against `input`, and setting
+    // `client.agentOrigin` must not change that outcome.
+    const client = AgentMeshClient.create('webmcp-agent', {
+      policyRules: [
+        { action: 'webmcp.checkout.pay', conditions: { assertedAgentOrigin: 'trusted.example' }, effect: 'allow' },
+        { action: '*', effect: 'deny' },
+      ],
+    });
+    const adapter = new GenericFrameworkAdapter(client);
+
+    // A forged `input.assertedAgentOrigin` is exactly what the policy
+    // condition above matches against -- proving the field it reads comes
+    // from page-controlled input, not from this module's `attributes`.
+    const forgedInvocation = toFrameworkInvocation(
+      { name: 'checkout.pay' },
+      { assertedAgentOrigin: 'trusted.example' },
+      { agentOrigin: 'attacker.example' },
+    );
+    const forgedResult = await adapter.run(forgedInvocation, async () => 'ok');
+    expect(forgedResult.allowed).toBe(true);
+
+    // A genuinely trustworthy `client.agentOrigin`, with no matching key in
+    // `input`, does NOT satisfy the same condition -- because attributes
+    // (where assertedAgentOrigin actually lands from `client`) are never
+    // consulted by policy at all.
+    const honestInvocation = toFrameworkInvocation(
+      { name: 'checkout.pay' },
+      {},
+      { agentOrigin: 'trusted.example' },
+    );
+    expect(honestInvocation.attributes).toEqual({ assertedAgentOrigin: 'trusted.example' });
+    const honestResult = await adapter.run(honestInvocation, async () => 'ok');
+    expect(honestResult.allowed).toBe(false);
+  });
+
+  it('runs through GenericFrameworkAdapter like any other framework invocation', async () => {
+    const client = AgentMeshClient.create('webmcp-agent', {
+      policyRules: [{ action: 'webmcp.email.createDraft', effect: 'allow' }],
+    });
+    const adapter = new GenericFrameworkAdapter(client);
+
+    const invocation = toFrameworkInvocation(
+      { name: 'email.createDraft', annotations: { readOnlyHint: false } },
+      { to: 'someone@example.com' },
+    );
+
+    const result = await adapter.run(invocation, async () => ({ draftId: 'draft-1' }));
+
+    expect(result.allowed).toBe(true);
+    expect(result.output).toEqual({ draftId: 'draft-1' });
+  });
+
+  it('denies the handler from running when policy blocks the mapped action', async () => {
+    const client = AgentMeshClient.create('webmcp-agent', {
+      policyRules: [{ action: '*', effect: 'deny' }],
+    });
+    const adapter = new GenericFrameworkAdapter(client);
+    const handler = jest.fn(async () => 'should-not-run');
+
+    const invocation = toFrameworkInvocation({ name: 'checkout.pay' }, { amount: 100 });
+    const result = await adapter.run(invocation, handler);
+
+    expect(result.allowed).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Related Issue
None — this doesn't fix an existing issue, so filling in the sections below.

## Problem & Solution
**Problem:** [WebMCP](https://github.com/webmachinelearning/webmcp) lets a web page register client-side tools via `document.modelContext.registerTool()`. A tool's `execute()` callback runs inside the page itself, and per the pattern discussed in [webmachinelearning/webmcp#105](https://github.com/webmachinelearning/webmcp/issues/105) ("Server-Side Verification"), it typically calls back into the site's own backend to do its real work. That backend call has no governance today — there's no policy check, audit trail, or trust scoring at the seam between "browser agent invoked this tool" and "backend performed the action."

**Solution:** Add `toFrameworkInvocation()` to `agent-governance-typescript`, which maps a WebMCP tool call (name, input, annotations, best-effort client info) into a `FrameworkInvocation`. That invocation runs through the existing `GenericFrameworkAdapter` exactly like any other framework integration — no new governance primitive, no code running inside the browser page. `agent-governance-typescript` itself is Node-oriented (`node:crypto`, `fs`), so this deliberately governs the backend call behind the WebMCP tool rather than attempting in-browser policy evaluation.

Only the two annotations merged into the WebMCP spec today (`readOnlyHint`, `untrustedContentHint`) are read explicitly. Everything else on `annotations` — including proposed-but-unmerged hints like `consequentialHint` ([webmachinelearning/webmcp#217](https://github.com/webmachinelearning/webmcp/issues/217)) — is passed through verbatim as an attribute, so this doesn't hard-code a shape that hasn't landed in the spec yet. Similarly, `client.agentOrigin` is treated as a best-effort hint, not verified identity, since agent identity on `ModelContextClient` is still an open proposal ([webmachinelearning/webmcp#96](https://github.com/webmachinelearning/webmcp/issues/96), [#105](https://github.com/webmachinelearning/webmcp/issues/105)).

## Impact on Your Work
I'm looking at whether AGT's existing policy/audit primitives are relevant to a few of WebMCP's open governance-shaped issues (#44, #96, #217). Before commenting on those threads, I wanted a real, tested implementation to point at rather than a hypothetical — this PR is that reference implementation.

## Timeline
None.

## Alternatives Considered
- **Run policy evaluation inside the browser page**, wrapping `registerTool()`'s `execute()` directly. Rejected: the SDK depends on `node:crypto`/`fs`, so it isn't browser-portable as-is, and per #105's own analysis, apps without a backend can't enforce anything meaningfully client-side anyway.
- **Hard-code `consequentialHint`/`humanInTheLoopHint` handling.** Rejected: neither is merged into the WebMCP spec (`consequentialHint` is still under active debate in #217; `humanInTheLoopHint` from #198 was effectively superseded). Passing annotations through generically avoids coupling this adapter to an unstable shape.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Package(s) Affected
- [x] agentmesh-integrations (framework integrations) — added under `agent-governance-typescript`, alongside the existing `GenericFrameworkAdapter`

## Testing

### Unit Testing
Added `tests/webmcp.test.ts` (6 tests): action-prefix mapping, default action naming, verbatim pass-through of unmerged annotations, best-effort `agentOrigin` handling, and two `GenericFrameworkAdapter.run()` integration tests (allow path executes the handler, deny path blocks it).

### Manual Testing
- `npx tsc --noEmit` — clean
- `npx eslint src/webmcp.ts tests/webmcp.test.ts` — clean
- `npx jest` — full suite: 39 suites / 580 tests passing (no regressions)
- `npx ts-node examples/webmcp-tool-governance.ts` — runs end-to-end, prints the expected governed output

## Checklist
- [x] I have linked a related issue above, or completed "Problem & Solution", "Impact on Your Work", and "Alternatives Considered"
- [x] My code follows the project style guidelines (ruff check) — N/A for this TS-only change; eslint passes
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest) — N/A, this is the TS SDK; `npx jest` passes (580/580)
- [x] I have updated documentation as needed
- [x] I have signed the Microsoft CLA (will sign via the CLA bot on this PR)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation

**Prior art / related projects:** WebMCP ([webmachinelearning/webmcp](https://github.com/webmachinelearning/webmcp), W3C Web Machine Learning Community Group) — the tool-registration model and the "server-side verification" pattern this PR builds on come directly from that spec's `ModelContextTool`/`registerTool()` design and issue #105's analysis.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

AI tools materially shaped this change: drafted with Claude Code (Claude), based on my review of both specs and the existing `GenericFrameworkAdapter`/`McpSecurityScanner` code in this repo — all code and this description reviewed and understood by me before submitting.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License