### PR TITLE
fix: update Copilot CLI js-yaml override

### DIFF
--- a/agent-governance-copilot-cli/package-lock.json
+++ b/agent-governance-copilot-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/agent-governance-copilot-cli",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/agent-governance-copilot-cli",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@microsoft/agent-governance-sdk": "4.0.0"
@@ -16,9 +16,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      },
-      "overrides": {
-        "js-yaml": "4.2.0"
       }
     },
     "node_modules/@microsoft/agent-governance-sdk": {
@@ -92,9 +89,19 @@
       "license": "Python-2.0"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/agent-governance-copilot-cli/package.json
+++ b/agent-governance-copilot-cli/package.json
@@ -36,7 +36,7 @@
     "@microsoft/agent-governance-sdk": "4.0.0"
   },
   "overrides": {
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.1"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/docs/dependency-audits/2026-09-02-copilot-cli-js-yaml-4.3.1.md
+++ b/docs/dependency-audits/2026-09-02-copilot-cli-js-yaml-4.3.1.md
@@ -1,0 +1,28 @@
+---
+title: Copilot CLI js-yaml 4.3.1 Dependency Audit
+last_reviewed: 2026-09-02
+owner: jstock03
+---
+
+# Copilot CLI js-yaml 4.3.1 Dependency Audit
+
+## Which dependencies changed and why
+
+- `js-yaml` changes from `4.2.0` to `4.3.1` in the Copilot CLI dependency graph.
+- The package remains transitive through `@microsoft/agent-governance-sdk@4.0.0`; the existing npm override selects the patched version without adding a dependency.
+- The lockfile root version changes from the stale `4.0.0` value to `5.0.0`, matching the existing package manifest. This metadata normalization does not change the dependency graph.
+- The lockfile was regenerated to keep installation reproducible and to remove the vulnerable parser version.
+
+## Security advisory relevance
+
+- CVE-2026-59869 affects `js-yaml` versions from `4.0.0` through versions before `4.3.0`. Version `4.3.1` contains the fix.
+- GHSA-5p4m-2wfm-xmqj affects `js-yaml` versions from `4.0.0` through versions before `4.3.1`. Version `4.3.1` is the first patched 4.x release.
+- The single upgrade therefore remediates S360 work items `332696` and `341590` for the Copilot CLI lockfile.
+- `npm audit` reports zero vulnerabilities after the lockfile update.
+
+## Breaking change risk assessment
+
+- Risk is low because the dependency remains within the `js-yaml` 4.x API line and is selected through the existing override mechanism.
+- The change does not modify Copilot CLI source code, package exports, runtime configuration, or the first-party SDK version.
+- Clean installation, syntax validation, and all 18 Copilot CLI tests pass with `js-yaml 4.3.1`.
+- Rollback consists of reverting the override and lockfile together, but doing so would restore both high-severity findings.

--- a/docs/dependency-audits/2026-09-02-copilot-cli-js-yaml-4.3.1.md
+++ b/docs/dependency-audits/2026-09-02-copilot-cli-js-yaml-4.3.1.md
@@ -1,8 +1,10 @@
 ---
 title: Copilot CLI js-yaml 4.3.1 Dependency Audit
 last_reviewed: 2026-09-02
-owner: jstock03
+owner: agt-maintainers
 ---
+
+<!-- cspell:words xmqj -->
 
 # Copilot CLI js-yaml 4.3.1 Dependency Audit
 


### PR DESCRIPTION
## Summary

Updates the Copilot CLI's `js-yaml` override and lockfile from `4.2.0` to `4.3.1`, the first 4.x release that fixes both reported high-severity denial-of-service advisories.

## Problem

S360 and Component Governance flag the Copilot CLI's overridden `js-yaml 4.2.0` for two related advisories. Both alerts apply to the same installed package instance:

- `CVE-2026-59869`: [AB#332696](https://dev.azure.com/AIP-RAI-Eng/d4b9f9c5-d834-47cc-b89c-31db2239a786/_workitems/edit/332696) and [Component Governance alert 17967443](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_componentGovernance/236562?alertId=17967443&branchMoniker=main)
- `GHSA-5p4m-2wfm-xmqj`: [AB#341590](https://dev.azure.com/AIP-RAI-Eng/d4b9f9c5-d834-47cc-b89c-31db2239a786/_workitems/edit/341590) and [Component Governance alert 18612941](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_componentGovernance/236562?alertId=18612941&branchMoniker=main)

## Changes

| File | Change |
|------|--------|
| `agent-governance-copilot-cli/package.json` | Raises the transitive `js-yaml` override to `4.3.1`. |
| `agent-governance-copilot-cli/package-lock.json` | Regenerates the lockfile with `js-yaml 4.3.1` and normalizes the package root version to the manifest's existing `5.0.0`. |
| `docs/dependency-audits/2026-09-02-copilot-cli-js-yaml-4.3.1.md` | Records the dependency change, advisory coverage, and compatibility risk required by repository policy. |

## Impact on Your Work

This removes the affected YAML parser version from the Copilot CLI dependency graph and clears both S360 findings after Component Governance rescans `main`.

## Alternatives Considered

- `js-yaml 4.3.0` fixes CVE-2026-59869 but remains affected by GHSA-5p4m-2wfm-xmqj, so `4.3.1` is the minimum complete fix.
- The open SDK 5.0.0 dependency bump retains the CLI's `4.2.0` override, so it does not remediate these findings by itself.

## Testing

- `npm ci`: clean install; zero vulnerabilities
- `npm ls js-yaml`: resolves `js-yaml 4.3.1 overridden`
- `npm audit`: zero vulnerabilities
- `npm run check`: passes
- `npm test`: 18/18 tests pass
- `scripts/ci/vendored-patch-audit.sh origin/main`: passes
- Dependency-audit frontmatter and link validation: zero findings

## Change Classification

- [x] Security fix
- [x] Maintenance dependency update
- [x] Copilot CLI plugin

## AI Assistance

GitHub Copilot applied the dependency-only update and ran the validation above at the contributor's request. Maintainer review is still required before merge.
