### PR TITLE
fix: paginate contributor_check.py search to stop silently dropping results past page 1

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/contributor_check.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/contributor_check.py
@@ -151,10 +151,31 @@ def _api(path: str, params: dict[str, str] | None = None) -> Any:
     return None
 
 
+# GitHub's search endpoints cap results at 1000 total (the "Search API"
+# result-window limit, documented at
+# https://docs.github.com/en/rest/search#about-search). A single request
+# only ever returns one page of up to `per_page` items, so a subject with
+# more issues/PRs than fit on the first page silently loses coverage on
+# exactly the pages most likely to contain the later, farther-out signal
+# a real spray/laundering pattern would produce. Page through the full
+# result window instead of trusting the first response alone. Mirrors the
+# identical fix already applied to credential_audit.py's `_search`.
+_SEARCH_RESULT_WINDOW = 1000
+
+
 def _search_issues(query: str, per_page: int = 30) -> list[dict]:
     """Search GitHub issues/PRs."""
-    data = _api("/search/issues", {"q": query, "per_page": str(per_page)})
-    return data.get("items", []) if data else []
+    items: list[dict] = []
+    max_pages = max(1, _SEARCH_RESULT_WINDOW // per_page)
+    for page in range(1, max_pages + 1):
+        data = _api("/search/issues", {"q": query, "per_page": str(per_page), "page": str(page)})
+        page_items = data.get("items", []) if data else []
+        if not page_items:
+            break
+        items.extend(page_items)
+        if len(page_items) < per_page:
+            break
+    return items
 
 
 # ---------------------------------------------------------------------------

--- a/agent-governance-python/agent-compliance/tests/test_contributor_check.py
+++ b/agent-governance-python/agent-compliance/tests/test_contributor_check.py
@@ -1,7 +1,9 @@
 """Tests for contributor check account shape analysis."""
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
+from agent_compliance.cli import contributor_check
 from agent_compliance.cli.contributor_check import check_account_shape
 
 
@@ -53,3 +55,52 @@ class TestCheckAccountShape:
         user = _make_user(created_at=recent_ts, public_repos=25)
         signals = check_account_shape(user)
         assert any(s.name == "new_account_burst" for s in signals)
+
+
+class TestSearchIssuesPagination:
+    """Mirrors credential_audit.py's identical fix: _search_issues must page
+    through GitHub's full search result window, not just the first page."""
+
+    def test_paginates_across_multiple_pages(self):
+        pages = {
+            "1": {"items": [{"number": i} for i in range(100)]},
+            "2": {"items": [{"number": i} for i in range(100, 150)]},
+        }
+
+        def fake_api(path, params=None):
+            return pages.get(params["page"])
+
+        with patch.object(contributor_check, "_api", side_effect=fake_api) as mock_api:
+            items = contributor_check._search_issues("author:x is:issue", per_page=100)
+
+        assert len(items) == 150
+        assert mock_api.call_count == 2
+
+    def test_stops_when_a_short_page_is_returned(self):
+        pages = {"1": {"items": [{"number": 1}, {"number": 2}]}}
+
+        def fake_api(path, params=None):
+            return pages.get(params["page"])
+
+        with patch.object(contributor_check, "_api", side_effect=fake_api) as mock_api:
+            items = contributor_check._search_issues("author:x is:issue", per_page=100)
+
+        assert len(items) == 2
+        assert mock_api.call_count == 1
+
+    def test_stops_at_github_search_result_window(self):
+        def fake_api(path, params=None):
+            return {"items": [{"number": i} for i in range(int(params["per_page"]))]}
+
+        with patch.object(contributor_check, "_api", side_effect=fake_api) as mock_api:
+            items = contributor_check._search_issues("author:x is:issue", per_page=100)
+
+        assert len(items) == 1000
+        assert mock_api.call_count == 10
+
+    def test_empty_first_page_returns_no_items(self):
+        with patch.object(contributor_check, "_api", return_value=None) as mock_api:
+            items = contributor_check._search_issues("author:x is:issue", per_page=100)
+
+        assert items == []
+        assert mock_api.call_count == 1

--- a/scripts/contributor_check.py
+++ b/scripts/contributor_check.py
@@ -95,10 +95,31 @@ def _api(path: str, params: dict[str, str] | None = None) -> Any:
             raise
 
 
+# GitHub's search endpoints cap results at 1000 total (the "Search API"
+# result-window limit, documented at
+# https://docs.github.com/en/rest/search#about-search). A single request
+# only ever returns one page of up to `per_page` items, so a subject with
+# more issues/PRs than fit on the first page silently loses coverage on
+# exactly the pages most likely to contain the later, farther-out signal
+# a real spray/laundering pattern would produce. Page through the full
+# result window instead of trusting the first response alone. Mirrors the
+# identical fix already applied to credential_audit.py's `_search`.
+_SEARCH_RESULT_WINDOW = 1000
+
+
 def _search_issues(query: str, per_page: int = 30) -> list[dict]:
     """Search GitHub issues/PRs."""
-    data = _api("/search/issues", {"q": query, "per_page": str(per_page)})
-    return data.get("items", []) if data else []
+    items: list[dict] = []
+    max_pages = max(1, _SEARCH_RESULT_WINDOW // per_page)
+    for page in range(1, max_pages + 1):
+        data = _api("/search/issues", {"q": query, "per_page": str(per_page), "page": str(page)})
+        page_items = data.get("items", []) if data else []
+        if not page_items:
+            break
+        items.extend(page_items)
+        if len(page_items) < per_page:
+            break
+    return items
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_contributor_check.py
+++ b/scripts/tests/test_contributor_check.py
@@ -18,6 +18,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import contributor_check
 from contributor_check import (
     Signal,
     ReputationReport,
@@ -807,3 +808,49 @@ class TestApplyAllowlist:
         _apply_allowlist(report)
         assert report.risk == "HIGH"
         assert any(s.name == "allowlist_blocked" for s in report.signals)
+
+
+class TestSearchIssuesPagination:
+    """Mirrors credential_audit.py's identical fix: _search_issues must page
+    through GitHub's full search result window, not just the first page."""
+
+    @patch("contributor_check._api")
+    def test_paginates_across_multiple_pages(self, mock_api):
+        pages = {
+            "1": {"items": [{"number": i} for i in range(100)]},
+            "2": {"items": [{"number": i} for i in range(100, 150)]},
+        }
+        mock_api.side_effect = lambda path, params=None: pages.get(params["page"])
+
+        items = contributor_check._search_issues("author:x is:issue", per_page=100)
+
+        assert len(items) == 150
+        assert mock_api.call_count == 2
+
+    @patch("contributor_check._api")
+    def test_stops_when_a_short_page_is_returned(self, mock_api):
+        pages = {"1": {"items": [{"number": 1}, {"number": 2}]}}
+        mock_api.side_effect = lambda path, params=None: pages.get(params["page"])
+
+        items = contributor_check._search_issues("author:x is:issue", per_page=100)
+
+        assert len(items) == 2
+        assert mock_api.call_count == 1
+
+    @patch("contributor_check._api")
+    def test_stops_at_github_search_result_window(self, mock_api):
+        mock_api.side_effect = lambda path, params=None: {
+            "items": [{"number": i} for i in range(int(params["per_page"]))]
+        }
+
+        items = contributor_check._search_issues("author:x is:issue", per_page=100)
+
+        assert len(items) == 1000
+        assert mock_api.call_count == 10
+
+    @patch("contributor_check._api", return_value=None)
+    def test_empty_first_page_returns_no_items(self, mock_api):
+        items = contributor_check._search_issues("author:x is:issue", per_page=100)
+
+        assert items == []
+        assert mock_api.call_count == 1


### PR DESCRIPTION
## What does this PR do?

Same bug as #3812 (`credential_audit.py`), found in its sibling tool: `contributor_check.py`'s `_search_issues()` only fetches the first page from GitHub's Search API (no `page` param), so a subject with more issues/PRs than fit on one page silently loses everything past it — no error, just an incomplete result set feeding the reputation-check signals this tool is built to compute. Flagged as a known follow-up in #3812's own description rather than fixed there, to keep that PR tight.

Same fix applied: page through the full 1000-result search window, stop on a short/last page — identical to the already-fixed `_search` in `credential_audit.py`. Fixed in both copies (`scripts/contributor_check.py` and the packaged `agent_compliance.cli.contributor_check` module), each with its own mirrored `TestSearchIssuesPagination` test class following that file's existing test-mocking convention (decorator-style `@patch` in the scripts suite, `patch.object` in the packaged-module suite).

**Verified locally**, not just compiled: `scripts/tests/test_contributor_check.py` — 61/61 pass (57 existing + 4 new). `agent-governance-python/agent-compliance/tests/test_contributor_check.py` — 7/7 pass (3 existing + 4 new). `ruff check`/`ruff format` show only pre-existing, unrelated issues in both files (confirmed by diffing against the unmodified file) — nothing introduced by this change.

## AI writing disclosure

AI-assisted: implemented by Claude Code under my direction, following the exact pattern already reviewed and (pending) approved in #3812.

## Who can review?

Same reviewers as #3812 — this is its direct sibling fix.