### PR TITLE
docs(adr): mark ADR-0030 accepted

### DIFF
--- a/docs/adr/0030-action-bound-approval-protocol.md
+++ b/docs/adr/0030-action-bound-approval-protocol.md
@@ -1,12 +1,12 @@
 ---
 title: Action-Bound, Fail-Closed Approval Protocol
-last_reviewed: 2026-06-11
+last_reviewed: 2026-09-06
 owner: agt-maintainers
 ---
 
 # ADR 0030: Use an action-bound, fail-closed approval protocol
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-06-11
 - Related issue: [#2478](https://github.com/microsoft/agent-governance-toolkit/issues/2478)
 


### PR DESCRIPTION
## Summary

- change ADR-0030 from `proposed` to `accepted`
- refresh the ADR review date

## Rationale

The Python implementation described by ADR-0030 landed through #3015, #3076,
#3096, #3097, #3100, and #3106. Maintainers closed the feature issue, #2478,
after confirming that scope was complete. Cross-SDK parity remains tracked
separately in #3083, as anticipated by the ADR migration plan.

The ADR index defines `accepted` as implemented, so the current `proposed`
label no longer reflects the shipped Python reference implementation.

PR #3891 owns the repository-wide index reconciliation, including the
ADR-0030 table move, so the two changes can merge in either order.

## Validation

- `python3 scripts/docs/check_links.py`
- `python3 scripts/docs/check_frontmatter.py --strict docs/adr/0030-action-bound-approval-protocol.md`
- changed-line cspell check
- `git diff --check`
