### PR TITLE
docs(adr): reconcile accepted and superseded statuses

### DIFF
--- a/docs/adr/0007-external-jwks-federation-for-cross-org-identity.md
+++ b/docs/adr/0007-external-jwks-federation-for-cross-org-identity.md
@@ -1,12 +1,12 @@
 ---
 title: "ADR 0007: External JWKS federation for cross-org agent identity"
-last_reviewed: 2026-05-18
+last_reviewed: 2026-09-06
 owner: agt-maintainers
 ---
 
 # ADR 0007: External JWKS federation for cross-org agent identity
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-04-23
 
 ## Context
@@ -249,9 +249,17 @@ This aligns with ADR-0001 (Ed25519 for agent identity) — the same key type and
 - Explicit-allowlist default means operators must configure each federation partner. This is intentionally conservative but adds operational overhead for large federations.
 - DNS/WebPKI trust anchor inherits the web's trust model, including its limitations (CA compromise, domain hijacking). DNSSEC and Certificate Transparency mitigate but do not eliminate these risks.
 
-**Follow-up work:**
+**Implementation:**
 
-- **Implementation PR:** `ExternalJWKSProvider` in `agentmesh/identity/` alongside the existing SPIFFE and Entra modules.
+- [PR #2380](https://github.com/microsoft/agent-governance-toolkit/pull/2380)
+  added `ExternalJWKSProvider`, delegation claims, federation policy, caching,
+  and revocation checks.
+- [PR #3094](https://github.com/microsoft/agent-governance-toolkit/pull/3094)
+  integrated external JWKS resolution into the handshake through
+  `IdentityProviderChain`.
+
+**Remaining follow-up work:**
+
 - **Federation policy configuration:** YAML/JSON schema for `FederationPolicy`, loadable from AGT's existing config system.
 - **Discovery registry:** Optional lightweight service for publishing and discovering federation endpoints across the ecosystem.
 - **DIF MCP-I alignment:** Map the provider interface to DIF's Mandatory DID + VC delegation chain (L2 standard) as that specification stabilizes.

--- a/docs/adr/0011-additive-policy-check-contract.md
+++ b/docs/adr/0011-additive-policy-check-contract.md
@@ -1,10 +1,12 @@
 ---
 title: Superseded Additive Check Contract
-last_reviewed: 2026-07-11
+last_reviewed: 2026-09-06
 owner: agt-maintainers
 ---
 
 # Superseded Additive Check Contract
+
+- Status: superseded
 
 This historical Agent OS decision is superseded by the native ACS verdict and
 `PolicyEvaluation` contract. New code must not recreate the removed

--- a/docs/adr/0014-parent-deny-rules-immutable-in-merge.md
+++ b/docs/adr/0014-parent-deny-rules-immutable-in-merge.md
@@ -1,10 +1,12 @@
 ---
 title: Superseded Folder Merge Rule
-last_reviewed: 2026-07-11
+last_reviewed: 2026-09-06
 owner: agt-maintainers
 ---
 
 # Superseded Folder Merge Rule
+
+- Status: superseded
 
 This historical folder-merge rule is retained only by the one-way migration
 command. Native runtime composition uses ACS `extends`.

--- a/docs/adr/0026-foundry-ai-gateway-functions-pdp.md
+++ b/docs/adr/0026-foundry-ai-gateway-functions-pdp.md
@@ -1,12 +1,12 @@
 ---
 title: "ADR 0026: Azure Functions PDP behind AI Gateway for Foundry prompt-based agents"
-last_reviewed: 2026-05-24
+last_reviewed: 2026-09-06
 owner: agt-maintainers
 ---
 
 # ADR 0026: Azure Functions PDP behind AI Gateway for Foundry prompt-based agents
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-05-24
 
 ## Context
@@ -88,3 +88,9 @@ boundary but must be communicated clearly in operator docs. Because the PDP
 sees a digest of prompt/tool input rather than the raw payload by default,
 PDP logic that needs the full text must opt in explicitly and accept the
 associated data-handling obligations.
+
+## Implementation
+
+[PR #2536](https://github.com/microsoft/agent-governance-toolkit/pull/2536)
+shipped the reference sample, APIM policy fragment, Azure Function, deployment
+template, and latency harness described by this decision.

--- a/docs/adr/0031-optional-embedding-detection-backend.md
+++ b/docs/adr/0031-optional-embedding-detection-backend.md
@@ -1,12 +1,12 @@
 ---
 title: "ADR 0031: Optional embedding evidence backend for prompt-injection detection"
-last_reviewed: 2026-06-15
+last_reviewed: 2026-09-06
 owner: agt-maintainers
 ---
 
 # ADR 0031: Optional embedding evidence backend for prompt-injection detection
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-06-13
 
 ## Context
@@ -80,6 +80,7 @@ for in-process telemetry and aggregation.
 
 ## References
 
+- [PR #3014](https://github.com/microsoft/agent-governance-toolkit/pull/3014): Python and Rust implementation.
 - ADR-0015 (pluggable external policy backends) — the pattern this follows.
 - #2918 — the embedding-signal proposal and the "connect it to the pipeline" gap.
 - RFC #2957 / PR #2991 — content normalization, upstream of any backend.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture Decision Records
-last_reviewed: 2026-06-11
+last_reviewed: 2026-09-06
 owner: agt-maintainers
 ---
 
@@ -19,10 +19,10 @@ Key architectural decisions and their rationale. Each ADR follows the standard f
 | [ADR-0002](0002-use-four-execution-rings-for-runtime-privilege.md) | Four execution rings for runtime privilege separation | Runtime |
 | [ADR-0003](0003-keep-iatp-handshake-within-200ms.md) | Keep IATP handshake under 200ms | Mesh |
 | [ADR-0004](0004-keep-policy-evaluation-deterministic.md) | Keep policy evaluation deterministic | Policy |
+| [ADR-0007](0007-external-jwks-federation-for-cross-org-identity.md) | External JWKS federation for cross-org identity | Identity |
 | [ADR-0009](0009-rfc-9334-rats-architecture-alignment.md) | RFC 9334 (RATS) architecture alignment | Standards |
 | [ADR-0012](0012-cost-governance-observability-policies.md) | Cost governance via observability policies | SRE |
 | [ADR-0013](0013-fail-closed-on-policy-evaluation-errors.md) | Fail closed on policy evaluation errors | Policy |
-| [ADR-0014](0014-parent-deny-rules-immutable-in-merge.md) | Parent deny rules are immutable in policy merge | Policy |
 | [ADR-0015](0015-pluggable-external-policy-backends.md) | Pluggable external policy backends via protocol interface | Policy |
 | [ADR-0016](0016-trust-ceiling-propagation-for-delegation.md) | Trust ceiling propagation for delegated agents | Trust |
 | [ADR-0017](0017-merkle-chain-for-audit-tamper-evidence.md) | Merkle chain for audit tamper evidence | Audit |
@@ -34,6 +34,10 @@ Key architectural decisions and their rationale. Each ADR follows the standard f
 | [ADR-0023](0023-append-only-delta-engine-for-hypervisor-audit.md) | Append-only delta engine for hypervisor audit | Audit |
 | [ADR-0024](0024-rl-training-governance-with-violation-penalties.md) | RL training governance with violation penalties | Lightning |
 | [ADR-0025](0025-structural-typing-for-sink-and-source-protocols.md) | Structural typing for sink and source protocols | Architecture |
+| [ADR-0026](0026-foundry-ai-gateway-functions-pdp.md) | Azure Functions PDP behind AI Gateway for Foundry prompt-based agents | Policy |
+| [ADR-0030](0030-action-bound-approval-protocol.md) | Action-bound, fail-closed approval protocol | Policy / Audit |
+| [ADR-0031](0031-optional-embedding-detection-backend.md) | Optional embedding evidence backend for prompt-injection detection | Security |
+| [ADR-0032](0032-agt-emits-trace-v01-trust-records.md) | AGT emits TRACE v0.1 Trust Records per session | Audit / Standards |
 
 ## Proposed
 
@@ -41,14 +45,15 @@ Key architectural decisions and their rationale. Each ADR follows the standard f
 |-----|----------|------|
 | [ADR-0005](0005-add-liveness-attestation-to-trust-handshake.md) | Add liveness attestation to TrustHandshake | Mesh |
 | [ADR-0006](0006-constitutional-constraint-layer-as-community-extension.md) | Constitutional constraint layer as community extension | Policy |
-| [ADR-0007](0007-external-jwks-federation-for-cross-org-identity.md) | External JWKS federation for cross-org identity | Identity |
 | [ADR-0008](0008-cross-org-policy-federation.md) | Cross-org policy federation above identity | Policy |
 | [ADR-0010](0010-tee-keystore-sevsnp-attestation.md) | TEE keystore with SEV-SNP attestation | Security |
-| [ADR-0011](0011-additive-policy-check-contract.md) | Additive policy check contract | Policy |
-| [ADR-0026](0026-foundry-ai-gateway-functions-pdp.md) | Azure Functions PDP behind AI Gateway for Foundry prompt-based agents | Policy |
 | [ADR-0027](0027-adopt-dual-stack-migration-for-mcp-2026-07-28.md) | Dual-stack migration for MCP `2026-07-28` | MCP |
 | [ADR-0028](0028-agt-studio-unified-ui.md) | AGT Studio, a single unified UI for governance | UI |
 | [ADR-0029](0029-policy-distribution-and-registries.md) | Policy distribution and registries with verifiable trust | Policy / Supply chain |
-| [ADR-0030](0030-action-bound-approval-protocol.md) | Action-bound, fail-closed approval protocol | Policy / Audit |
-| [ADR-0031](0031-optional-embedding-detection-backend.md) | Optional embedding evidence backend for prompt-injection detection | Security |
-| [ADR-0032](0032-agt-emits-trace-v01-trust-records.md) | AGT emits TRACE v0.1 Trust Records per session | Audit / Standards |
+
+## Superseded
+
+| ADR | Decision | Area |
+|-----|----------|------|
+| [ADR-0011](0011-additive-policy-check-contract.md) | Additive policy check contract | Policy |
+| [ADR-0014](0014-parent-deny-rules-immutable-in-merge.md) | Parent deny rules are immutable in policy merge | Policy |


### PR DESCRIPTION
## Summary

- reconcile the ADR index with implementation state across the repository
- mark ADR-0007, ADR-0026, and ADR-0031 as accepted
- move ADR-0032 to Accepted because its file already records that status
- move ADR-0030 to Accepted alongside the file correction in #3890
- classify ADR-0011 and ADR-0014 as superseded after the v4 policy-language removal
- add implementation links to the promoted ADRs

PR #3890 owns ADR-0030's file status. This PR owns the complete index
reconciliation, so the two changes can merge in either order.

## Audit evidence

| ADR | Corrected status | Evidence |
|-----|------------------|----------|
| 0007 | accepted | External JWKS provider in #2380 and handshake integration in #3094 |
| 0011 | superseded | The ADR stub points to the native ACS verdict and `PolicyEvaluation` replacement |
| 0014 | superseded | The ADR stub points to ACS `extends` and the one-way v4 migration path |
| 0026 | accepted | Runnable Foundry AI Gateway PDP reference implementation in #2536 |
| 0030 | accepted | Python implementation in #3015, #3076, #3096, #3097, #3100, and #3106; file status in #3890 |
| 0031 | accepted | Python and Rust evidence-backend implementation in #3014 |
| 0032 | accepted | The ADR file already says accepted; implementation landed in #3098 and #3099 |

The audit retained ADR-0005, ADR-0006, ADR-0008, ADR-0010, ADR-0027,
ADR-0028, and ADR-0029 as proposed. Their defined implementation is absent,
partial, or still tracked. Examples include the open ADR-0010 handshake work
in #3162, the open Studio epic in #2729, and the repository's continued MCP
`2025-11-25` implementation rather than ADR-0027's proposed `2026-07-28`
dual-stack design.

## Validation

- `python3 scripts/docs/check_links.py`
- `python3 scripts/docs/check_frontmatter.py --strict` on all changed pages
- changed-line cspell check
- ADR index uniqueness and file-status checks
- `git diff --check`
