### PR TITLE
docs(compliance): add stable per-control anchors for external deep links

### DIFF
--- a/docs/compliance/atf-conformance-assessment.md
+++ b/docs/compliance/atf-conformance-assessment.md
@@ -41,6 +41,8 @@ The toolkit targets Senior maturity level, meeting all MUST requirements for tha
 
 ### Element 1: Identity ("Who are you?")
 
+<a id="i-1-unique-identifier"></a>
+
 #### I-1: Unique Identifier — ✅ FULLY MET
 
 Every agent receives a globally unique `did:mesh:<fingerprint>` identifier derived from an Ed25519 keypair.
@@ -52,6 +54,8 @@ Every agent receives a globally unique `did:mesh:<fingerprint>` identifier deriv
 | Enterprise AAD binding | `agent-governance-python/agent-mesh/identity/entra.py` — `EntraAgentIdentity` |
 | .NET package | `AgentGovernance/Trust/AgentIdentity.cs` — `Create()` |
 | Rust crate | `agentmesh/src/identity.rs` — `AgentIdentity::generate()` |
+
+<a id="i-2-credential-binding"></a>
 
 #### I-2: Credential Binding — ✅ FULLY MET
 
@@ -65,6 +69,8 @@ Agent identity is bound to Ed25519 cryptographic credentials. Every handshake, d
 | mTLS cert binding | `agent-governance-python/agent-mesh/identity/mtls.py` |
 | Plugin signing | `agent-governance-python/agent-marketplace/signing.py` — `PluginSigner` |
 
+<a id="i-3-ownership-chain"></a>
+
 #### I-3: Ownership Chain — ✅ FULLY MET
 
 Full delegation chain with parent DID tracking, depth limiting, and capability narrowing.
@@ -75,6 +81,8 @@ Full delegation chain with parent DID tracking, depth limiting, and capability n
 | Chain verification | `agent-governance-python/agent-mesh/identity/agent_id.py` — `verify_delegation_chain()` |
 | Scope chains | `agent-governance-python/agent-mesh/identity/delegation.py` — `ScopeChain` |
 | Capability narrowing | Child capabilities must be subset of parent capabilities |
+
+<a id="i-4-purpose-declaration"></a>
 
 #### I-4: Purpose Declaration — ⚠️ PARTIALLY MET
 
@@ -87,6 +95,8 @@ Purpose is captured across multiple subsystems but lacks a unified machine-reada
 | Credential purpose | `agent-governance-python/agent-mesh/identity/credentials.py` — `Credential.issued_for` |
 
 **Gap:** No universal `PurposeDeclaration` model enforced at identity creation time. Purpose is fragmented across model cards, policy rules, and credential fields.
+
+<a id="i-5-capability-manifest"></a>
 
 #### I-5: Capability Manifest — ✅ FULLY MET
 
@@ -103,6 +113,8 @@ Machine-readable capability declarations for both agents and plugins.
 
 ### Element 2: Behavioral Monitoring ("What are you doing?")
 
+<a id="b-1-structured-logging"></a>
+
 #### B-1: Structured Logging — ✅ FULLY MET
 
 Tamper-evident audit chains with Merkle tree integrity verification.
@@ -114,6 +126,8 @@ Tamper-evident audit chains with Merkle tree integrity verification.
 | Audit trail | `agent-governance-python/agent-hypervisor/audit/delta.py` — `DeltaEngine` |
 | OTel integration | `agent-governance-python/agent-mesh/observability/otel_sdk.py` |
 
+<a id="b-2-action-attribution"></a>
+
 #### B-2: Action Attribution — ⚠️ PARTIALLY MET
 
 Actions are attributed to agent identities, but naming conventions vary across packages.
@@ -124,6 +138,8 @@ Actions are attributed to agent identities, but naming conventions vary across p
 | Hypervisor tracking | `agent-governance-python/agent-hypervisor/audit/delta.py` — `agent_did` per entry |
 
 **Gap:** Inconsistent field naming (`agent_id` vs `agent_did` vs `AgentId`) across packages. No shared `Attribution` model.
+
+<a id="b-3-behavioral-baseline"></a>
 
 #### B-3: Behavioral Baseline — ⚠️ PARTIALLY MET
 
@@ -137,6 +153,8 @@ Behavioral baselines with drift detection, but limited cross-session persistence
 
 **Gap:** Baselines are in-memory only — no durable cross-session persistence.
 
+<a id="b-4-anomaly-detection"></a>
+
 #### B-4: Anomaly Detection — ✅ FULLY MET
 
 Multi-signal anomaly detection with automated response.
@@ -147,6 +165,8 @@ Multi-signal anomaly detection with automated response.
 | Ring breach detector | `agent-governance-python/agent-hypervisor/rings/breach_detector.py` — sliding-window anomaly |
 | Drift scoring | `agent-governance-python/agent-os/integrations/drift_detector.py` — `DriftType` enum |
 | Fleet anomaly | `agent-governance-python/agent-sre/fleet/__init__.py` — fleet-wide health monitoring |
+
+<a id="b-5-explainability"></a>
 
 #### B-5: Explainability — ✅ FULLY MET
 
@@ -163,6 +183,8 @@ Every policy decision includes a machine-readable reason.
 
 ### Element 3: Data Governance ("What are you eating? What are you serving?")
 
+<a id="d-1-schema-validation"></a>
+
 #### D-1: Schema Validation — ✅ FULLY MET
 
 Input validation via Pydantic models, JSON Schema, and YAML policy schemas.
@@ -174,6 +196,8 @@ Input validation via Pydantic models, JSON Schema, and YAML policy schemas.
 | CLI validation | `agent-governance-python/agent-os/cli/cmd_validate.py` — JSON Schema + structural |
 | OWASP compliance | `agent-governance-python/agent-compliance/verify.py` |
 
+<a id="d-2-injection-prevention"></a>
+
 #### D-2: Injection Prevention — ✅ FULLY MET
 
 Multi-layer prompt injection defense with 12+ detection patterns.
@@ -184,6 +208,8 @@ Multi-layer prompt injection defense with 12+ detection patterns.
 | MCP tool poisoning scanner | `agent-governance-python/agent-os/mcp_security.py` — `MCPSecurityScanner` |
 | Memory guard | `agent-governance-python/agent-os/memory_guard.py` — memory poisoning defense |
 | Allowlist/blocklist validation | `agent-governance-python/agent-os/prompt_injection.py` — validated + frozen in `__post_init__` |
+
+<a id="d-3-pii-phi-protection"></a>
 
 #### D-3: PII/PHI Protection — ⚠️ PARTIALLY MET
 
@@ -197,6 +223,8 @@ Regex-based PII detection with redaction, but no ML-based classification.
 
 **Gap:** Regex-only PII detection. No ML-based NER (e.g., Presidio) integration for complex PII/PHI patterns.
 
+<a id="d-4-output-validation"></a>
+
 #### D-4: Output Validation — ✅ FULLY MET
 
 Content quality evaluation with multi-dimensional scoring.
@@ -207,6 +235,8 @@ Content quality evaluation with multi-dimensional scoring.
 | Quality assessment | `agent-governance-python/agent-marketplace/quality_assessment.py` — `QualityAssessor` |
 | Output policies | `agent-governance-python/agent-os/templates/policies/content-safety.yaml` |
 | Drift detection | `agent-governance-python/agent-os/integrations/drift_detector.py` |
+
+<a id="d-5-data-lineage"></a>
 
 #### D-5: Data Lineage — ⚠️ PARTIALLY MET
 
@@ -224,6 +254,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 
 ### Element 4: Segmentation ("Where can you go?")
 
+<a id="s-1-resource-allowlist"></a>
+
 #### S-1: Resource Allowlist — ✅ FULLY MET
 
 | Component | Location |
@@ -232,6 +264,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 | Per-org MCP policies | `agent-governance-python/agent-marketplace/marketplace_policy.py` — `get_effective_mcp_policy()` |
 | Egress policy | `agent-governance-python/agent-os/egress_policy.py` — domain-level allow/deny |
 | Tool allowlists | `agent-governance-python/agent-os/mcp_gateway.py` — `MCPGateway` |
+
+<a id="s-2-action-boundaries"></a>
 
 #### S-2: Action Boundaries — ✅ FULLY MET
 
@@ -242,6 +276,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 | Capability gating | `agent-governance-python/agent-mesh/trust/capability.py` — `CapabilityScope` |
 | Context-aware enforcement | `agent-governance-python/agent-os/execution_context_policy.py` — `ContextualPolicyEngine` |
 
+<a id="s-3-rate-limiting"></a>
+
 #### S-3: Rate Limiting — ✅ FULLY MET
 
 | Component | Location |
@@ -251,6 +287,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 | MCP gateway limits | `agent-governance-python/agent-os/mcp_gateway.py` |
 | .NET rate limiter | `AgentGovernance/Hypervisor/RateLimiter.cs` |
 
+<a id="s-4-transaction-limits"></a>
+
 #### S-4: Transaction Limits — ✅ FULLY MET
 
 | Component | Location |
@@ -259,6 +297,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 | Max tool calls | `agent-governance-python/agent-os/integrations/base.py` — `AgentControl.max_tool_calls` |
 | Budget enforcement | `agent-governance-python/agent-os/context_budget.py` — `ContextScheduler` |
 | Execution context limits | `agent-governance-python/agent-os/execution_context_policy.py` |
+
+<a id="s-5-blast-radius-containment"></a>
 
 #### S-5: Blast Radius Containment — ✅ FULLY MET
 
@@ -273,6 +313,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 
 ### Element 5: Incident Response ("What if you go rogue?")
 
+<a id="r-1-circuit-breaker"></a>
+
 #### R-1: Circuit Breaker — ✅ FULLY MET
 
 | Component | Location |
@@ -280,6 +322,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 | Python circuit breaker | `agent-governance-python/agent-sre/cascade/circuit_breaker.py` — trip/open/half-open state machine |
 | .NET circuit breaker | `AgentGovernance/Sre/CircuitBreaker.cs` |
 | Cascade detector | `agent-governance-python/agent-sre/cascade/circuit_breaker.py` — `CascadeDetector` |
+
+<a id="r-2-kill-switch"></a>
 
 #### R-2: Kill Switch — ✅ FULLY MET
 
@@ -290,6 +334,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 | CLI kill | `agent-governance-python/agent-hypervisor/cli/session_commands.py` — `cmd_kill` |
 | Saga compensation | Handoff to substitutes, in-flight step compensation |
 
+<a id="r-3-session-revocation"></a>
+
 #### R-3: Session Revocation — ✅ FULLY MET
 
 | Component | Location |
@@ -299,6 +345,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 | Identity suspension | `agent-governance-python/agent-mesh/identity/agent_id.py` — `suspend()`, `reactivate()` |
 | Capability stripping | `agent-governance-python/agent-mesh/trust/capability.py` — `revoke_all_from()` |
 
+<a id="r-4-state-rollback"></a>
+
 #### R-4: State Rollback — ✅ FULLY MET
 
 | Component | Location |
@@ -307,6 +355,8 @@ Execution-trace-level lineage via flight recorder and audit chains, but no datas
 | Reversibility registry | `agent-governance-python/agent-hypervisor/reversibility/registry.py` |
 | VFS snapshots | `agent-governance-python/agent-hypervisor/session/__init__.py` — `create_vfs_snapshot()` |
 | .NET sagas | `AgentGovernance/Hypervisor/SagaOrchestrator.cs` |
+
+<a id="r-5-graceful-degradation"></a>
 
 #### R-5: Graceful Degradation — ⚠️ PARTIALLY MET
 

--- a/docs/compliance/owasp-asi-policy-mapping.md
+++ b/docs/compliance/owasp-asi-policy-mapping.md
@@ -26,70 +26,70 @@ Cross-references every rule in the ASI starter policy packs
 
 | Rule Name | Pack(s) | ASI Risk(s) | AGT Component |
 |-----------|---------|-------------|---------------|
-| `asi01-prompt-injection-override` | All | ASI-01 | Agent OS — Policy Engine |
-| `asi01-prompt-injection-role-hijack` | All | ASI-01 | Agent OS — Policy Engine |
-| `asi01-prompt-injection-delimiter` | All | ASI-01 | Agent OS — MCP Proxy Sanitizer |
-| `healthcare-asi01-cbrn-guardrail` | healthcare | ASI-01 | Agent OS — Policy Engine |
-| `asi01-prompt-injection-jailbreak` | general-saas | ASI-01 | Agent OS — Policy Engine |
-| `asi01-integrity-shipping-guardrail` | All | ASI-01, ASI-02 | Business Continuity — Logistics Guard |
-| `asi01-integrity-fraud-guardrail` | All | ASI-01, ASI-02 | Business Continuity — Fraud Guard |
-| `asi01-nested-swarm-guardrail` | general-saas | ASI-01 | AgentMesh — Delegation Guard |
-| `asi02-block-shell-execution` | All | ASI-02 | Agent OS — Capability Sandboxing |
-| `asi02-block-network-exfiltration` | All | ASI-02 | Agent OS — Capability Sandboxing |
-| `asi02-block-file-deletion` | healthcare | ASI-02 | Agent OS — Capability Sandboxing |
-| `asi02-block-destructive-operations` | financial-services, general-saas | ASI-02 | Agent OS — Capability Sandboxing |
-| `financial-asi02-obfuscation-guardrail` | financial-services | ASI-02 | Agent OS — Binary Inspector |
-| `asi02-block-database-mutation` | general-saas | ASI-02 | Agent SRE — Audit Trail |
-| `asi03-block-privilege-escalation` | All | ASI-03 | AgentMesh — DID Identity & Trust |
-| `asi03-block-credential-access` | All | ASI-03 | AgentMesh — DID Identity & Trust |
-| `financial-asi03-identity-guardrail` | financial-services | ASI-03 | AgentMesh — Trust Boundary |
-| `asi03-block-user-impersonation` | general-saas | ASI-03 | AgentMesh — DID Identity & Trust |
-| `asi03-account-mfa-bypass` | All | ASI-03 | AgentMesh — Identity Governance |
-| `asi03-account-admin-promotion` | All | ASI-03 | AgentMesh — Identity Governance |
-| `asi03-account-password-reset` | All | ASI-03 | AgentMesh — Identity Governance |
-| `asi03-account-audit-tampering` | All | ASI-03 | AgentMesh — Identity Governance |
-| `asi04-supply-chain-tool-enumeration` | All | ASI-04 | Agent OS — Recon Guard |
-| `asi04-supply-chain-dependency-poisoning` | All | ASI-04 | Agent OS — Payload Guard |
-| `asi04-supply-chain-plugin-hijack` | All | ASI-04 | Agent OS — Registry Proxy |
-| `asi04-supply-chain-config-mutation` | All | ASI-04 | Agent OS — State Guard |
-| `asi05-block-code-execution` | All | ASI-05 | Agent Runtime — Execution Rings |
-| `asi05-block-dynamic-eval` | All | ASI-05 | Agent Runtime — Execution Rings |
-| `asi05-sandbox-anti-pattern-detection` | All | ASI-05 | Agent Runtime — Context Guard |
-| `asi05-block-ssh` | general-saas | ASI-05 | Agent Runtime — Execution Rings |
-| `asi06-context-budget-limit` | All | ASI-06 | Agent OS — VFS / ContextScheduler |
-| `asi06-block-context-manipulation` | All | ASI-06 | Agent OS — Context Integrity Firewall |
-| `asi07-hidden-channel-guardrail` | All | ASI-07 | AgentMesh — Signal Monitor |
-| `asi08-session-tool-call-limit` | All | ASI-08 | Agent SRE — Circuit Breakers |
-| `asi08-swarm-heat-guardrail` | All | ASI-08 | Agent SRE — Swarm Monitor |
-| `asi09-trust-payment-redirection` | All | ASI-09 | Business Continuity — Trust Firewall |
-| `asi09-trust-vip-impersonation` | All | ASI-09 | Business Continuity — Trust Firewall |
-| `asi09-trust-urgency-pretext` | All | ASI-09 | Business Continuity — Trust Firewall |
-| `asi09-trust-phishing-link` | All | ASI-09 | Business Continuity — Trust Firewall |
-| `asi10-charter-roleplay-block` | All | ASI-10 | Agent OS — Charter Enforcement |
-| `asi10-charter-purpose-override` | All | ASI-10 | Agent OS — Charter Enforcement |
-| `asi10-charter-autonomous-loop` | All | ASI-10 | Agent OS — Charter Enforcement |
-| `asi03-block-credentials-in-output` | All | ASI-02, ASI-03 | Agent OS — Policy Engine |
-| `asi06-block-pii-ssn` | All | ASI-01, ASI-06 | Agent OS — PII Protection |
-| `healthcare-block-phi-mrn` | healthcare | ASI-01, ASI-06 | Agent OS — PII Protection |
-| `healthcare-block-phi-dea` | healthcare | ASI-01, ASI-06 | Agent OS — PII Protection |
-| `healthcare-enforce-deidentification` | healthcare | ASI-02, ASI-06 | Agent OS — Data Pipeline Security |
-| `financial-block-pii-credit-card` | financial-services | ASI-01, ASI-06 | Agent OS — PII Protection |
-| `saas-block-pii-email-bulk` | general-saas | ASI-02, ASI-06 | Agent OS — PII Protection |
-| `edu-asi01-homework-bypass` | edu-k12 | ASI-01 | Agent OS — Policy Engine |
-| `edu-asi01-content-filter-bypass` | edu-k12 | ASI-01 | Agent OS — Policy Engine |
-| `edu-asi02-block-grade-mutation` | edu-k12 | ASI-02 | Agent OS — Capability Sandboxing |
-| `edu-asi02-block-record-write` | edu-k12 | ASI-02 | Agent OS — Capability Sandboxing |
-| `edu-asi03-block-student-impersonation` | edu-k12 | ASI-03 | AgentMesh — DID Identity & Trust |
-| `edu-asi06-block-curriculum-poisoning` | edu-k12 | ASI-06 | Agent OS — Context Integrity Firewall |
-| `edu-asi09-parental-impersonation` | edu-k12 | ASI-09 | Business Continuity — Trust Firewall |
-| `edu-asi09-block-minor-contact-info` | edu-k12 | ASI-09 | Agent OS — PII Protection |
-| `edu-block-student-id` | edu-k12 | ASI-01, ASI-06 | Agent OS — PII Protection |
-| `edu-block-phi-iep` | edu-k12 | ASI-01, ASI-06 | Agent OS — PII Protection |
-| `edu-block-disciplinary-record` | edu-k12 | ASI-01, ASI-06 | Agent OS — PII Protection |
-| `edu-cipa-block-adult-content` | edu-k12 | ASI-01, ASI-06 | Agent OS — Policy Engine |
-| `edu-cipa-block-violence-content` | edu-k12 | ASI-01, ASI-06 | Agent OS — Policy Engine |
-| `edu-block-credentials-in-output` | edu-k12 | ASI-02, ASI-03 | Agent OS — Policy Engine |
-| `edu-ferpa-audit-record-access` | edu-k12 | ASI-01, ASI-06 | Agent OS — Audit Trail |
+| <a id="asi01-prompt-injection-override"></a>`asi01-prompt-injection-override` | All | ASI-01 | Agent OS — Policy Engine |
+| <a id="asi01-prompt-injection-role-hijack"></a>`asi01-prompt-injection-role-hijack` | All | ASI-01 | Agent OS — Policy Engine |
+| <a id="asi01-prompt-injection-delimiter"></a>`asi01-prompt-injection-delimiter` | All | ASI-01 | Agent OS — MCP Proxy Sanitizer |
+| <a id="healthcare-asi01-cbrn-guardrail"></a>`healthcare-asi01-cbrn-guardrail` | healthcare | ASI-01 | Agent OS — Policy Engine |
+| <a id="asi01-prompt-injection-jailbreak"></a>`asi01-prompt-injection-jailbreak` | general-saas | ASI-01 | Agent OS — Policy Engine |
+| <a id="asi01-integrity-shipping-guardrail"></a>`asi01-integrity-shipping-guardrail` | All | ASI-01, ASI-02 | Business Continuity — Logistics Guard |
+| <a id="asi01-integrity-fraud-guardrail"></a>`asi01-integrity-fraud-guardrail` | All | ASI-01, ASI-02 | Business Continuity — Fraud Guard |
+| <a id="asi01-nested-swarm-guardrail"></a>`asi01-nested-swarm-guardrail` | general-saas | ASI-01 | AgentMesh — Delegation Guard |
+| <a id="asi02-block-shell-execution"></a>`asi02-block-shell-execution` | All | ASI-02 | Agent OS — Capability Sandboxing |
+| <a id="asi02-block-network-exfiltration"></a>`asi02-block-network-exfiltration` | All | ASI-02 | Agent OS — Capability Sandboxing |
+| <a id="asi02-block-file-deletion"></a>`asi02-block-file-deletion` | healthcare | ASI-02 | Agent OS — Capability Sandboxing |
+| <a id="asi02-block-destructive-operations"></a>`asi02-block-destructive-operations` | financial-services, general-saas | ASI-02 | Agent OS — Capability Sandboxing |
+| <a id="financial-asi02-obfuscation-guardrail"></a>`financial-asi02-obfuscation-guardrail` | financial-services | ASI-02 | Agent OS — Binary Inspector |
+| <a id="asi02-block-database-mutation"></a>`asi02-block-database-mutation` | general-saas | ASI-02 | Agent SRE — Audit Trail |
+| <a id="asi03-block-privilege-escalation"></a>`asi03-block-privilege-escalation` | All | ASI-03 | AgentMesh — DID Identity & Trust |
+| <a id="asi03-block-credential-access"></a>`asi03-block-credential-access` | All | ASI-03 | AgentMesh — DID Identity & Trust |
+| <a id="financial-asi03-identity-guardrail"></a>`financial-asi03-identity-guardrail` | financial-services | ASI-03 | AgentMesh — Trust Boundary |
+| <a id="asi03-block-user-impersonation"></a>`asi03-block-user-impersonation` | general-saas | ASI-03 | AgentMesh — DID Identity & Trust |
+| <a id="asi03-account-mfa-bypass"></a>`asi03-account-mfa-bypass` | All | ASI-03 | AgentMesh — Identity Governance |
+| <a id="asi03-account-admin-promotion"></a>`asi03-account-admin-promotion` | All | ASI-03 | AgentMesh — Identity Governance |
+| <a id="asi03-account-password-reset"></a>`asi03-account-password-reset` | All | ASI-03 | AgentMesh — Identity Governance |
+| <a id="asi03-account-audit-tampering"></a>`asi03-account-audit-tampering` | All | ASI-03 | AgentMesh — Identity Governance |
+| <a id="asi04-supply-chain-tool-enumeration"></a>`asi04-supply-chain-tool-enumeration` | All | ASI-04 | Agent OS — Recon Guard |
+| <a id="asi04-supply-chain-dependency-poisoning"></a>`asi04-supply-chain-dependency-poisoning` | All | ASI-04 | Agent OS — Payload Guard |
+| <a id="asi04-supply-chain-plugin-hijack"></a>`asi04-supply-chain-plugin-hijack` | All | ASI-04 | Agent OS — Registry Proxy |
+| <a id="asi04-supply-chain-config-mutation"></a>`asi04-supply-chain-config-mutation` | All | ASI-04 | Agent OS — State Guard |
+| <a id="asi05-block-code-execution"></a>`asi05-block-code-execution` | All | ASI-05 | Agent Runtime — Execution Rings |
+| <a id="asi05-block-dynamic-eval"></a>`asi05-block-dynamic-eval` | All | ASI-05 | Agent Runtime — Execution Rings |
+| <a id="asi05-sandbox-anti-pattern-detection"></a>`asi05-sandbox-anti-pattern-detection` | All | ASI-05 | Agent Runtime — Context Guard |
+| <a id="asi05-block-ssh"></a>`asi05-block-ssh` | general-saas | ASI-05 | Agent Runtime — Execution Rings |
+| <a id="asi06-context-budget-limit"></a>`asi06-context-budget-limit` | All | ASI-06 | Agent OS — VFS / ContextScheduler |
+| <a id="asi06-block-context-manipulation"></a>`asi06-block-context-manipulation` | All | ASI-06 | Agent OS — Context Integrity Firewall |
+| <a id="asi07-hidden-channel-guardrail"></a>`asi07-hidden-channel-guardrail` | All | ASI-07 | AgentMesh — Signal Monitor |
+| <a id="asi08-session-tool-call-limit"></a>`asi08-session-tool-call-limit` | All | ASI-08 | Agent SRE — Circuit Breakers |
+| <a id="asi08-swarm-heat-guardrail"></a>`asi08-swarm-heat-guardrail` | All | ASI-08 | Agent SRE — Swarm Monitor |
+| <a id="asi09-trust-payment-redirection"></a>`asi09-trust-payment-redirection` | All | ASI-09 | Business Continuity — Trust Firewall |
+| <a id="asi09-trust-vip-impersonation"></a>`asi09-trust-vip-impersonation` | All | ASI-09 | Business Continuity — Trust Firewall |
+| <a id="asi09-trust-urgency-pretext"></a>`asi09-trust-urgency-pretext` | All | ASI-09 | Business Continuity — Trust Firewall |
+| <a id="asi09-trust-phishing-link"></a>`asi09-trust-phishing-link` | All | ASI-09 | Business Continuity — Trust Firewall |
+| <a id="asi10-charter-roleplay-block"></a>`asi10-charter-roleplay-block` | All | ASI-10 | Agent OS — Charter Enforcement |
+| <a id="asi10-charter-purpose-override"></a>`asi10-charter-purpose-override` | All | ASI-10 | Agent OS — Charter Enforcement |
+| <a id="asi10-charter-autonomous-loop"></a>`asi10-charter-autonomous-loop` | All | ASI-10 | Agent OS — Charter Enforcement |
+| <a id="asi03-block-credentials-in-output"></a>`asi03-block-credentials-in-output` | All | ASI-02, ASI-03 | Agent OS — Policy Engine |
+| <a id="asi06-block-pii-ssn"></a>`asi06-block-pii-ssn` | All | ASI-01, ASI-06 | Agent OS — PII Protection |
+| <a id="healthcare-block-phi-mrn"></a>`healthcare-block-phi-mrn` | healthcare | ASI-01, ASI-06 | Agent OS — PII Protection |
+| <a id="healthcare-block-phi-dea"></a>`healthcare-block-phi-dea` | healthcare | ASI-01, ASI-06 | Agent OS — PII Protection |
+| <a id="healthcare-enforce-deidentification"></a>`healthcare-enforce-deidentification` | healthcare | ASI-02, ASI-06 | Agent OS — Data Pipeline Security |
+| <a id="financial-block-pii-credit-card"></a>`financial-block-pii-credit-card` | financial-services | ASI-01, ASI-06 | Agent OS — PII Protection |
+| <a id="saas-block-pii-email-bulk"></a>`saas-block-pii-email-bulk` | general-saas | ASI-02, ASI-06 | Agent OS — PII Protection |
+| <a id="edu-asi01-homework-bypass"></a>`edu-asi01-homework-bypass` | edu-k12 | ASI-01 | Agent OS — Policy Engine |
+| <a id="edu-asi01-content-filter-bypass"></a>`edu-asi01-content-filter-bypass` | edu-k12 | ASI-01 | Agent OS — Policy Engine |
+| <a id="edu-asi02-block-grade-mutation"></a>`edu-asi02-block-grade-mutation` | edu-k12 | ASI-02 | Agent OS — Capability Sandboxing |
+| <a id="edu-asi02-block-record-write"></a>`edu-asi02-block-record-write` | edu-k12 | ASI-02 | Agent OS — Capability Sandboxing |
+| <a id="edu-asi03-block-student-impersonation"></a>`edu-asi03-block-student-impersonation` | edu-k12 | ASI-03 | AgentMesh — DID Identity & Trust |
+| <a id="edu-asi06-block-curriculum-poisoning"></a>`edu-asi06-block-curriculum-poisoning` | edu-k12 | ASI-06 | Agent OS — Context Integrity Firewall |
+| <a id="edu-asi09-parental-impersonation"></a>`edu-asi09-parental-impersonation` | edu-k12 | ASI-09 | Business Continuity — Trust Firewall |
+| <a id="edu-asi09-block-minor-contact-info"></a>`edu-asi09-block-minor-contact-info` | edu-k12 | ASI-09 | Agent OS — PII Protection |
+| <a id="edu-block-student-id"></a>`edu-block-student-id` | edu-k12 | ASI-01, ASI-06 | Agent OS — PII Protection |
+| <a id="edu-block-phi-iep"></a>`edu-block-phi-iep` | edu-k12 | ASI-01, ASI-06 | Agent OS — PII Protection |
+| <a id="edu-block-disciplinary-record"></a>`edu-block-disciplinary-record` | edu-k12 | ASI-01, ASI-06 | Agent OS — PII Protection |
+| <a id="edu-cipa-block-adult-content"></a>`edu-cipa-block-adult-content` | edu-k12 | ASI-01, ASI-06 | Agent OS — Policy Engine |
+| <a id="edu-cipa-block-violence-content"></a>`edu-cipa-block-violence-content` | edu-k12 | ASI-01, ASI-06 | Agent OS — Policy Engine |
+| <a id="edu-block-credentials-in-output"></a>`edu-block-credentials-in-output` | edu-k12 | ASI-02, ASI-03 | Agent OS — Policy Engine |
+| <a id="edu-ferpa-audit-record-access"></a>`edu-ferpa-audit-record-access` | edu-k12 | ASI-01, ASI-06 | Agent OS — Audit Trail |
 
 ---
 
@@ -128,10 +128,10 @@ Cross-references every rule in the ASI starter policy packs
 
 | Pack | Default Action | Max Tokens | Max Tool Calls | Confidence |
 |------|:--------------:|:----------:|:--------------:|:----------:|
-| `healthcare` | `deny` | 8,192 | 15 | 0.95 |
-| `financial-services` | `deny` | 6,000 | 20 | 0.95 |
-| `general-saas` | `deny` | 12,000 | 30 | 0.85 |
-| `edu-k12` | `deny` | 4,096 | 10 | 0.90 |
+| <a id="healthcare"></a>`healthcare` | `deny` | 8,192 | 15 | 0.95 |
+| <a id="financial-services"></a>`financial-services` | `deny` | 6,000 | 20 | 0.95 |
+| <a id="general-saas"></a>`general-saas` | `deny` | 12,000 | 30 | 0.85 |
+| <a id="edu-k12"></a>`edu-k12` | `deny` | 4,096 | 10 | 0.90 |
 
 All packs implement **deny-all by default**, enforcing the
 [Least Agency principle](owasp-agentic-top10-architecture.md).


### PR DESCRIPTION
Refs #3811.

Adds stable per-control anchors to the two docs that carry the control taxonomy, so OpenCRE (and any other external standard) can deep link to a control and keep resolving.

### Anchor scheme

**`docs/compliance/atf-conformance-assessment.md`** — 25 anchors, one per requirement, `<control-id>-<name-slug>`:

```
<a id="i-3-ownership-chain"></a>

#### I-3: Ownership Chain — ✅ FULLY MET
```

That is the exact form the issue asked for. It matters that these are explicit rather than generated: the headings carry their conformance status inline, so the generated anchor for I-3 is `#i-3-ownership-chain--fully-met` today and becomes `#i-3-ownership-chain--partially-met` the moment the status changes. That is precisely the rot the issue calls out as worse than no anchor.

**`docs/compliance/owasp-asi-policy-mapping.md`** — 68 anchors, one per policy rule. The rules live in table rows, not headings, so there is nothing to generate an anchor from at all. Each anchor is keyed on the rule name itself (`#asi01-prompt-injection-override`) rather than a slug of surrounding prose, because the rule name *is* the durable identifier — it is what the policy packs are keyed on, so it cannot be reworded without a rule rename.

### Why `<a id>` rather than `{#id}`

`attr_list` is enabled in `mkdocs.yml`, so `{#i-3-ownership-chain}` would work on the docs site. I used the HTML-anchor form because these compliance docs are also read directly on GitHub, which does not support `attr_list` and would render the braces as literal text. It is also the form already established in `docs/compliance/nist-ai-rmf-alignment.md`.

### Verified

- 25 + 68 = 93 anchors, all unique within their file, all matching `[a-z0-9][a-z0-9-]*`.
- Rendered both files through python-markdown with the site's `attr_list`, `md_in_html`, `tables` and `toc` extensions: 93 anchors present in the output, `#i-3-ownership-chain` and `#asi01-prompt-injection-override` both resolve, and the tables still render (93 and 128 rows) — the inline anchor in the first cell does not break the row.
- No prose, status, or mapping content changed; the diff is anchors only.

Out of scope per the issue: the mapping content itself.
