### PR TITLE
ci: add a non-blocking Windows test job (closes #3884)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1280,6 +1280,121 @@ jobs:
   # jobs report "skipped" which doesn't satisfy required status checks.
   # This gate job always runs, checks that no jobs FAILED, and reports
   # success. Configure this as the single required status check.
+  # -- Windows visibility (reports only, never gates) --------------------
+  test-windows:
+    needs: changes
+    # The Python suite has never run on Windows: every one of the 98 test jobs
+    # in .github/workflows is a Linux runner, and the only Windows runner in
+    # the repository builds the win_amd64 wheel in publish.yml without testing
+    # it. The package documents Python 3.9+ "on any platform", ships
+    # scripts/quickstart.ps1 as the Windows install path, and publishes that
+    # wheel, so the gap is invisible to a Windows operator until something
+    # silently does not fire (#3831).
+    #
+    # This job exists to measure the gap, not to enforce it. It is absent from
+    # ci-complete's needs list and carries continue-on-error, so a failure here
+    # reports and does not block a merge. Promote it once the failures it finds
+    # are triaged. See #3884.
+    continue-on-error: true
+    runs-on: windows-latest
+    defaults:
+      run:
+        # windows-latest ships Git Bash, so the gate and install steps below are
+        # the same shell as the Linux job rather than a second PowerShell copy
+        # that would drift from it.
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        # The packages that need neither OPA nor the native ACS Rust SDK. The
+        # five ACS-backed packages (agent-os, agt-policies, agent-compliance,
+        # agent-marketplace, agent-sandbox) need a Windows OPA binary and a
+        # maturin build on Windows; both are their own piece of work and would
+        # bury the pure-Python signal this job is for.
+        package:
+          [
+            agent-mesh,
+            agent-hypervisor,
+            agent-sre,
+            agent-runtime,
+            agent-lightning,
+            agent-primitives,
+            agent-mcp-governance,
+            agent-discovery,
+            agent-rag-governance,
+          ]
+        # One version rather than the Linux job's four: this is a smoke signal,
+        # and the cost of a Windows runner is roughly twice a Linux one.
+        python-version: [ "3.13" ]
+    steps:
+      - name: Determine if package changed
+        id: gate
+        env:
+          CHANGED: ${{ needs.changes.outputs.changed-py-pkgs }}
+          PKG: ${{ matrix.package }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "push" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s' "$CHANGED" | grep -q "\"$PKG\""; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Package $PKG unchanged on this PR - skipping Windows tests."
+          fi
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: steps.gate.outputs.run == 'true'
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: steps.gate.outputs.run == 'true'
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install local sibling dependencies
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          pip install --no-cache-dir --no-deps -e agent-governance-python/agent-governance-toolkit-core
+          pip install --no-cache-dir --no-deps -e agent-governance-python/agent-governance-toolkit-integrations
+          pip install --no-cache-dir --no-deps -e agent-governance-python/agent-governance-toolkit-cli
+          pip install --no-cache-dir --no-deps -e agent-governance-python/agent-governance-toolkit-protocols
+          pip install --no-cache-dir "pydantic>=2.5.0,<3.0" "pyyaml>=6.0,<7.0"
+          pip install --no-cache-dir --no-deps -e agent-governance-python/agt-policies
+          pip install --no-cache-dir --no-deps -e agent-governance-python/agent-hypervisor
+      - name: Install ${{ matrix.package }}
+        if: steps.gate.outputs.run == 'true'
+        working-directory: agent-governance-python/${{ matrix.package }}
+        env:
+          PKG: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          case "$PKG" in
+            agent-runtime|agent-mcp-governance)
+              pip install --no-cache-dir -e .
+              ;;
+            agent-mesh|agent-hypervisor|agent-sre|agent-lightning|agent-primitives|agent-discovery|agent-rag-governance)
+              pip install --no-cache-dir -e ".[dev]"
+              ;;
+            *)
+              echo "::error::Unknown package '$PKG' - update the install case in the Windows job" >&2
+              exit 1
+              ;;
+          esac
+          CI_TEST_REQS="$GITHUB_WORKSPACE/agent-governance-python/requirements/ci-test.txt"
+          if [ -f "$CI_TEST_REQS" ]; then
+            pip install --no-cache-dir --require-hashes -r "$CI_TEST_REQS"
+          else
+            echo "::warning::ci-test.txt not found at $CI_TEST_REQS - skipping shared test deps"
+          fi
+      - name: Test ${{ matrix.package }} on Windows
+        if: steps.gate.outputs.run == 'true'
+        working-directory: agent-governance-python/${{ matrix.package }}
+        run: |
+          if [ -d tests ]; then
+            pytest tests/ -q --tb=short
+          else
+            echo "No tests/ directory - skipping package tests"
+          fi
+
   ci-complete:
     if: always()
     needs:


### PR DESCRIPTION
Closes #3884, taking the "suggested minimal step" from the issue.

## Confirmed on current `main`

```
$ grep -h -oE "runs-on:.*" .github/workflows/*.yml | sort | uniq -c
      1 runs-on: ${{ matrix.os }}
      1 runs-on: ubuntu-24.04
     98 runs-on: ubuntu-latest

$ grep -riE "windows" .github/workflows/
.github/workflows/publish.yml:  - { os: windows-2022, platform: windows-x86_64, ... }

$ grep -c "runs-on" .github/workflows/ci.yml
19
```

One Windows runner in the repository, and it builds the `win_amd64` wheel without running the suite on it. `ci.yml` -- the file #310's acceptance criteria named -- has no `windows` and no `macos`.

## What this adds

A `test-windows` job that reports and cannot gate:

- `continue-on-error: true`
- **not** in `ci-complete`'s `needs` list, so it is invisible to the merge gate rather than merely tolerated by it

Both are deliberate. The suite has never run on Windows, so the first run is a measurement, not a pass/fail. Promote the job once its failures are triaged.

## Scope, and what is left out

Nine packages -- the ones needing neither OPA nor the native ACS Rust SDK:

```
agent-mesh, agent-hypervisor, agent-sre, agent-runtime, agent-lightning,
agent-primitives, agent-mcp-governance, agent-discovery, agent-rag-governance
```

The five ACS-backed packages (`agent-os`, `agt-policies`, `agent-compliance`, `agent-marketplace`, `agent-sandbox`) are excluded: they need a Windows OPA binary and a maturin build on Windows, each its own piece of work, and putting them in the first run would bury the pure-Python signal this job exists for.

One Python version (3.13) rather than the Linux job's four, since a Windows runner costs about twice a Linux one and this is a smoke signal.

## Keeping it from drifting

Steps default to `shell: bash`, which `windows-latest` ships via Git for Windows, so the change-gate and install logic is the same shell as the Linux `test` job rather than a second PowerShell transcription that would drift from it. Actions use the same pinned SHAs already in this file.

## Validation

```
$ python -c "yaml.safe_load(...)"          # parses; 20 jobs
  test-windows present:      True
  continue-on-error:         True
  runs-on:                   windows-latest
  in ci-complete needs:      False
  matrix packages:           9

$ actionlint .github/workflows/ci.yml      # rhysd/actionlint container
  1 finding, with this job and on main alike (a pre-existing SC2193 at
  build-pypi, line 509, untouched here)
```

I cannot run a GitHub Windows runner locally, so what the first run reports is genuinely unknown -- that is the point of the job, and the reason it is non-blocking. If you would rather start with a single package, or on a schedule only rather than on pull requests, say which and I will narrow it.