### PR TITLE
feat(sidecar): bind decisions to policy-load provenance

### DIFF
--- a/agent-governance-python/agent-mesh/README.md
+++ b/agent-governance-python/agent-mesh/README.md
@@ -757,6 +757,8 @@ last-loaded-wins behavior.
 
 `GET /api/v1/policies` includes the current manifest's `files`: filename, raw-byte
 SHA-256 digest (or null if unreadable), load status, and exception class on failure.
+Filenames use Python `unicode_escape` text, escaping backslashes, non-ASCII
+characters, and undecodable filesystem bytes without conflating their names.
 Raw policy content and exception messages are omitted. `policy_set_id` is `sha256:`
 followed by the SHA-256 of UTF-8 encoded Python
 `json.dumps({"directory_status": ..., "files": ...}, sort_keys=True, separators=(",", ":"))`
@@ -774,8 +776,10 @@ an atomic filesystem snapshot of a concurrently changing directory.
 Each completed manifest is also emitted once per load at INFO as
 `Policy load generation: {...}`. Retain those deployment logs with decision records
 to resolve historical IDs after reload/restart; the API exposes only the current
-manifest. Filenames and digests may themselves be sensitive, so apply the same
-access and retention controls as other policy diagnostics.
+manifest. The sidecar does not authenticate `GET /api/v1/policies`; anyone who can
+reach it can read these filenames and digests. Restrict access through deployment
+network controls or an authenticated proxy, and protect retained logs as policy
+diagnostics because filenames and digests may themselves be sensitive.
 
 ## Contributing
 

--- a/agent-governance-python/agent-mesh/README.md
+++ b/agent-governance-python/agent-mesh/README.md
@@ -742,6 +742,41 @@ verifier rejects unsupported `alg` headers (including `none` and
 `HS*`) **before** the JWKS lookup as defense-in-depth against
 algorithm-confusion attacks.
 
+## Sidecar policy-load provenance
+
+The governance sidecar (`agentmesh.server.sidecar`) includes `policy_set_id` and
+`policy_set_status` on every `POST /api/v1/policy/evaluate` response. Each decision
+uses one engine/manifest snapshot, even if a reload publishes another generation
+during evaluation. This metadata does not change allow/deny behavior.
+
+`GET /ready` and `POST /api/v1/policy/reload` also report `policies_discovered`,
+`policies_loaded`, and `policies_failed`. These count discovered `.yaml` and `.json`
+files, not distinct policy names or policies expected by an operator. YAML files
+load in name order before JSON files; duplicate policy names retain the existing
+last-loaded-wins behavior.
+
+`GET /api/v1/policies` includes the current manifest's `files`: filename, raw-byte
+SHA-256 digest (or null if unreadable), load status, and exception class on failure.
+Raw policy content and exception messages are omitted. `policy_set_id` is `sha256:`
+followed by the SHA-256 of UTF-8 encoded Python
+`json.dumps({"directory_status": ..., "files": ...}, sort_keys=True, separators=(",", ":"))`
+with the default ASCII escaping. File order is load order. Failed content and load
+outcomes contribute to identity; identical manifests reuse the same ID. The ID is
+a content reference, not a unique reload timestamp or a cryptographic attestation.
+
+Status is `complete` after discovery and all file loads succeed, `degraded` after
+a file failure or unavailable directory, and `not_loaded` before initial loading.
+An available empty directory is complete; this does not establish that every
+required policy was deployed. Existing readiness and permissive partial-loading
+behavior remain unchanged. A generation describes bytes actually read; it is not
+an atomic filesystem snapshot of a concurrently changing directory.
+
+Each completed manifest is also emitted once per load at INFO as
+`Policy load generation: {...}`. Retain those deployment logs with decision records
+to resolve historical IDs after reload/restart; the API exposes only the current
+manifest. Filenames and digests may themselves be sensitive, so apply the same
+access and retention controls as other policy diagnostics.
+
 ## Contributing
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.

--- a/agent-governance-python/agent-mesh/src/agentmesh/server/sidecar.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/server/sidecar.py
@@ -253,7 +253,7 @@ def _load_policies() -> PolicyLoadGeneration:
                 logger.warning("Skipped policy %r: %s", f.name, error_type)
             files.append(
                 PolicyFileLoad(
-                    name=f.name,
+                    name=f.name.encode("unicode_escape").decode("ascii"),
                     content_sha256=digest,
                     status="failed" if error_type else "loaded",
                     error_type=error_type,
@@ -275,9 +275,10 @@ def _load_policies() -> PolicyLoadGeneration:
         directory_status=directory_status,
         files=tuple(files),
     )
+    serialized = generation.model_dump_json()
     _policy_state = (engine, generation)
     # ponytail: retain historical manifests through deployment logs, not an unbounded cache.
-    logger.info("Policy load generation: %s", generation.model_dump_json())
+    logger.info("Policy load generation: %s", serialized)
     return generation
 
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/server/sidecar.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/server/sidecar.py
@@ -16,16 +16,19 @@ Environment variables:
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
-from agentmesh.governance.policy import PolicyEngine as _PolicyEngine
 from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentmesh.governance.policy import PolicyEngine as _PolicyEngine
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +65,7 @@ def create_sidecar_app() -> FastAPI:
         return {
             "status": "ready",
             "component": "governance-sidecar",
-            "policies_loaded": _loaded_count,
+            **_policy_state[1].model_dump(exclude={"files"}),
         }
 
     @app.get("/healthz", tags=["health"])
@@ -81,7 +84,7 @@ def create_sidecar_app() -> FastAPI:
     async def metrics_endpoint() -> PlainTextResponse:
         """Prometheus exposition format metrics."""
         try:
-            from prometheus_client import generate_latest, REGISTRY
+            from prometheus_client import REGISTRY, generate_latest
 
             output = generate_latest(REGISTRY).decode("utf-8")
             uptime = time.monotonic() - _start_time
@@ -122,28 +125,37 @@ def create_sidecar_app() -> FastAPI:
             "resource": req.resource,
             **req.context,
         }
-        result: PolicyDecision = _engine.evaluate(agent_did=req.agent_did, context=ctx)
+        engine, generation = _policy_state
+        result: PolicyDecision = engine.evaluate(agent_did=req.agent_did, context=ctx)
         return EvaluateResponse(
             decision=result.action,
             matched_rule=result.matched_rule,
             reason=result.reason,
             policy_name=result.policy_name,
+            policy_set_id=generation.policy_set_id,
+            policy_set_status=generation.policy_set_status,
         )
 
     @app.get("/api/v1/policies", tags=["policy"])
     async def list_policies() -> dict[str, Any]:
         """List loaded policies."""
+        generation = _policy_state[1]
         return {
-            "total_loaded": _loaded_count,
+            "total_loaded": generation.policies_loaded,
             "policy_dir": _policy_dir,
             "version": VERSION,
+            **generation.model_dump(),
         }
 
     @app.post("/api/v1/policy/reload", tags=["policy"])
     async def reload_policies() -> dict[str, Any]:
         """Hot-reload policies from disk."""
-        _load_policies()
-        return {"status": "reloaded", "total_loaded": _loaded_count}
+        generation = _load_policies()
+        return {
+            "status": "reloaded",
+            "total_loaded": generation.policies_loaded,
+            **generation.model_dump(exclude={"files"}),
+        }
 
     return app
 
@@ -163,50 +175,110 @@ class EvaluateResponse(BaseModel):
     matched_rule: str | None = None
     reason: str = ""
     policy_name: str | None = None
+    policy_set_id: str
+    policy_set_status: Literal["complete", "degraded", "not_loaded"]
+
+
+class PolicyFileLoad(BaseModel):
+    """One discovered file, without raw policy content or exception messages."""
+
+    model_config = ConfigDict(frozen=True)
+    name: str
+    content_sha256: str | None
+    status: Literal["loaded", "failed"]
+    error_type: str | None = None
+
+
+class PolicyLoadGeneration(BaseModel):
+    """Immutable manifest of a completed load; counts refer to files, not unique names."""
+
+    model_config = ConfigDict(frozen=True)
+    policy_set_id: str
+    policy_set_status: Literal["complete", "degraded", "not_loaded"]
+    policies_discovered: int
+    policies_loaded: int
+    policies_failed: int
+    directory_status: Literal["available", "unavailable", "not_loaded"]
+    files: tuple[PolicyFileLoad, ...]
 
 
 # ── Internal state ───────────────────────────────────────────────────
 
 _policy_dir = os.getenv("AGT_POLICY_DIR", "/etc/agt/policies")
-_loaded_count = 0
+_policy_state = (
+    _PolicyEngine(),
+    PolicyLoadGeneration(
+        policy_set_id="sha256:" + hashlib.sha256(b"not_loaded").hexdigest(),
+        policy_set_status="not_loaded",
+        policies_discovered=0,
+        policies_loaded=0,
+        policies_failed=0,
+        directory_status="not_loaded",
+        files=(),
+    ),
+)
 
-# Initialize engine eagerly so tests work without startup event
-_engine = _PolicyEngine()
 
-
-def _load_policies() -> None:
-    """Load policies from AGT_POLICY_DIR."""
-    global _engine, _loaded_count, _policy_dir
+def _load_policies() -> PolicyLoadGeneration:
+    """Build then publish an engine and its content-addressed load manifest together."""
+    global _policy_state, _policy_dir
 
     from agentmesh.governance.policy import PolicyEngine
 
     _policy_dir = os.getenv("AGT_POLICY_DIR", "/etc/agt/policies")
-    _engine = PolicyEngine()
+    engine = PolicyEngine()
 
     policy_path = Path(_policy_dir)
-    if not policy_path.exists():
-        logger.warning("Policy directory %s does not exist", _policy_dir)
-        _loaded_count = 0
-        return
+    files = []
+    directory_status: Literal["available", "unavailable"] = "available"
+    try:
+        # iterdir surfaces discovery errors instead of silently claiming an empty load.
+        discovered = list(policy_path.iterdir())
+    except OSError:
+        discovered = []
+        directory_status = "unavailable"
+        logger.warning("Policy directory is unavailable")
 
-    count = 0
-    for f in sorted(policy_path.glob("*.yaml")):
-        try:
-            _engine.load_yaml(f.read_text())
-            count += 1
-            logger.info("Loaded policy: %s", f.name)
-        except Exception as exc:
-            logger.warning("Skipped %s: %s", f.name, exc)
+    # Preserve YAML-before-JSON precedence for duplicate policy names.
+    for suffix, loader in ((".yaml", engine.load_yaml), (".json", engine.load_json)):
+        for f in sorted(p for p in discovered if p.suffix == suffix):
+            digest = None
+            error_type = None
+            try:
+                content = f.read_bytes()
+                digest = hashlib.sha256(content).hexdigest()
+                loader(content.decode("utf-8"))
+            except Exception as exc:
+                error_type = type(exc).__name__
+                logger.warning("Skipped policy %r: %s", f.name, error_type)
+            files.append(
+                PolicyFileLoad(
+                    name=f.name,
+                    content_sha256=digest,
+                    status="failed" if error_type else "loaded",
+                    error_type=error_type,
+                )
+            )
 
-    for f in sorted(policy_path.glob("*.json")):
-        try:
-            _engine.load_json(f.read_text())
-            count += 1
-        except Exception as exc:
-            logger.warning("Skipped %s: %s", f.name, exc)
-
-    _loaded_count = count
-    logger.info("Loaded %d policies from %s", count, _policy_dir)
+    manifest = {
+        "directory_status": directory_status,
+        "files": [entry.model_dump() for entry in files],
+    }
+    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+    failed = sum(entry.status == "failed" for entry in files)
+    generation = PolicyLoadGeneration(
+        policy_set_id="sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+        policy_set_status="degraded" if failed or directory_status == "unavailable" else "complete",
+        policies_discovered=len(files),
+        policies_loaded=len(files) - failed,
+        policies_failed=failed,
+        directory_status=directory_status,
+        files=tuple(files),
+    )
+    _policy_state = (engine, generation)
+    # ponytail: retain historical manifests through deployment logs, not an unbounded cache.
+    logger.info("Policy load generation: %s", generation.model_dump_json())
+    return generation
 
 
 def _bootstrap_telemetry() -> None:

--- a/agent-governance-python/agent-mesh/tests/test_sidecar.py
+++ b/agent-governance-python/agent-mesh/tests/test_sidecar.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 from unittest.mock import patch
 
@@ -15,6 +17,7 @@ from fastapi.testclient import TestClient
 def client():
     """Create a test client for the sidecar app."""
     from agentmesh.server.sidecar import create_sidecar_app
+
     app = create_sidecar_app()
     return TestClient(app)
 
@@ -134,7 +137,8 @@ class TestPolicyWithFiles:
             "    reason: 'Shell execution blocked'\n"
         )
         with patch.dict(os.environ, {"AGT_POLICY_DIR": str(tmp_path)}):
-            from agentmesh.server.sidecar import create_sidecar_app, _load_policies
+            from agentmesh.server.sidecar import _load_policies, create_sidecar_app
+
             app = create_sidecar_app()
             _load_policies()
             return TestClient(app)
@@ -170,3 +174,127 @@ class TestOpenAPIDocs:
         assert resp.status_code == 200
         data = resp.json()
         assert "AGT Governance Sidecar" in data["info"]["title"]
+
+
+@pytest.fixture
+def generation_client(tmp_path, monkeypatch):
+    from agentmesh.server import sidecar
+
+    monkeypatch.setenv("AGT_POLICY_DIR", str(tmp_path))
+    monkeypatch.setattr(sidecar, "_policy_state", sidecar._policy_state)
+    monkeypatch.setattr(sidecar, "_policy_dir", sidecar._policy_dir)
+    sidecar._load_policies()
+    return TestClient(sidecar.create_sidecar_app())
+
+
+def test_generation_records_success_and_rejected_files(generation_client, tmp_path, caplog):
+    (tmp_path / "allow.yaml").write_text("name: allow\nrules: []\n", encoding="utf-8")
+    (tmp_path / "deny.json").write_text('{"name": "deny", "rules": []}', encoding="utf-8")
+    rejected = tmp_path / "broken.yaml"
+    rejected.write_text("rules: [", encoding="utf-8")
+    with caplog.at_level("INFO", logger="agentmesh.server.sidecar"):
+        response = generation_client.post("/api/v1/policy/reload").json()
+    manifest = generation_client.get("/api/v1/policies").json()
+    assert response["policies_discovered"] == 3
+    assert response["policies_loaded"] == 2
+    assert response["policies_failed"] == 1
+    assert response["policy_set_status"] == "degraded"
+    assert response["policy_set_id"] in caplog.text
+    assert "rules: [" not in caplog.text
+    failed = next(f for f in manifest["files"] if f["name"] == "broken.yaml")
+    assert failed["status"] == "failed"
+    assert failed["error_type"]
+    assert failed["content_sha256"] == hashlib.sha256(rejected.read_bytes()).hexdigest()
+    canonical = json.dumps(
+        {"directory_status": manifest["directory_status"], "files": manifest["files"]},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    assert response["policy_set_id"] == "sha256:" + hashlib.sha256(canonical.encode()).hexdigest()
+    decision = generation_client.post(
+        "/api/v1/policy/evaluate",
+        json={"agent_did": "did:mesh:test", "action": "read"},
+    ).json()
+    assert decision["policy_set_id"] == response["policy_set_id"]
+    assert decision["policy_set_status"] == "degraded"
+    assert generation_client.get("/ready").json()["policy_set_id"] == response["policy_set_id"]
+
+
+def test_generation_identity_tracks_failed_content_and_absence(generation_client, tmp_path):
+    def reload_id():
+        return generation_client.post("/api/v1/policy/reload").json()["policy_set_id"]
+
+    empty = reload_id()
+    assert reload_id() == empty
+    rejected = tmp_path / "broken.json"
+    rejected.write_text("{", encoding="utf-8")
+    first = reload_id()
+    assert first != empty
+    assert reload_id() == first
+    rejected.write_text("{ ", encoding="utf-8")
+    assert reload_id() != first
+    rejected.unlink()
+    assert reload_id() == empty
+
+
+def test_unavailable_directory_is_not_complete_empty_load(generation_client, tmp_path, monkeypatch):
+    complete = generation_client.get("/api/v1/policies").json()
+    monkeypatch.setenv("AGT_POLICY_DIR", str(tmp_path / "absent"))
+    degraded = generation_client.post("/api/v1/policy/reload").json()
+    assert complete["policy_set_status"] == "complete"
+    assert degraded["policy_set_status"] == "degraded"
+    assert degraded["directory_status"] == "unavailable"
+    assert degraded["policies_discovered"] == degraded["policies_failed"] == 0
+    assert complete["policy_set_id"] != degraded["policy_set_id"]
+
+
+def test_unreadable_file_is_recorded(generation_client, tmp_path):
+    # A directory with a policy extension is discovered but cannot be read as a file.
+    (tmp_path / "unreadable.yaml").mkdir()
+    generation_client.post("/api/v1/policy/reload")
+    manifest = generation_client.get("/api/v1/policies").json()
+    assert manifest["policies_failed"] == 1
+    assert manifest["files"][0]["content_sha256"] is None
+    assert manifest["files"][0]["error_type"]
+
+
+def test_evaluation_keeps_its_generation_when_reload_publishes(
+    generation_client, tmp_path, monkeypatch
+):
+    from agentmesh.server import sidecar
+
+    policy = tmp_path / "policy.yaml"
+    policy.write_text(
+        "name: guard\nagents: ['*']\nrules:\n"
+        "- name: block\n  condition: \"action == 'send'\"\n  action: deny\n",
+        encoding="utf-8",
+    )
+    old_generation = sidecar._load_policies()
+    old_engine = sidecar._policy_state[0]
+    evaluate = old_engine.evaluate
+
+    def evaluate_while_reloading(*args, **kwargs):
+        policy.write_text(
+            "name: guard\nagents: ['*']\nrules:\n"
+            "- name: permit\n  condition: \"action == 'send'\"\n  action: allow\n",
+            encoding="utf-8",
+        )
+        sidecar._load_policies()
+        return evaluate(*args, **kwargs)
+
+    monkeypatch.setattr(old_engine, "evaluate", evaluate_while_reloading)
+    result = generation_client.post(
+        "/api/v1/policy/evaluate",
+        json={"agent_did": "did:mesh:test", "action": "send"},
+    ).json()
+    assert result["decision"] == "deny"
+    assert result["matched_rule"] == "block"
+    assert result["policy_set_id"] == old_generation.policy_set_id
+    assert sidecar._policy_state[1].policy_set_id != old_generation.policy_set_id
+    next_result = generation_client.post(
+        "/api/v1/policy/evaluate",
+        json={"agent_did": "did:mesh:test", "action": "send"},
+    ).json()
+    assert next_result["decision"] == "allow", next_result
+    assert next_result["matched_rule"] == "permit"
+    assert next_result["policy_set_id"] == sidecar._policy_state[1].policy_set_id

--- a/agent-governance-python/agent-mesh/tests/test_sidecar.py
+++ b/agent-governance-python/agent-mesh/tests/test_sidecar.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -258,7 +259,7 @@ def test_unreadable_file_is_recorded(generation_client, tmp_path):
     assert manifest["files"][0]["error_type"]
 
 
-@pytest.mark.skipif(os.name != "posix", reason="Undecodable byte filenames require POSIX")
+@pytest.mark.skipif(sys.platform != "linux", reason="Undecodable byte filename test requires Linux")
 def test_generation_handles_undecodable_filenames(generation_client, tmp_path, caplog):
     content = b"name: unusual\nrules: []\n"
     names = [b"bad\xff.yaml", b"bad\\udcff.yaml", "café.yaml".encode()]

--- a/agent-governance-python/agent-mesh/tests/test_sidecar.py
+++ b/agent-governance-python/agent-mesh/tests/test_sidecar.py
@@ -258,6 +258,51 @@ def test_unreadable_file_is_recorded(generation_client, tmp_path):
     assert manifest["files"][0]["error_type"]
 
 
+@pytest.mark.skipif(os.name != "posix", reason="Undecodable byte filenames require POSIX")
+def test_generation_handles_undecodable_filenames(generation_client, tmp_path, caplog):
+    content = b"name: unusual\nrules: []\n"
+    names = [b"bad\xff.yaml", b"bad\\udcff.yaml", "café.yaml".encode()]
+    for name in names:
+        with open(os.fsencode(tmp_path) + b"/" + name, "wb") as policy:
+            policy.write(content)
+
+    # Entering the client runs startup, including policy loading and JSON logging.
+    with caplog.at_level("INFO", logger="agentmesh.server.sidecar"), generation_client:
+        response = generation_client.get("/api/v1/policies")
+        assert response.status_code == 200
+        manifest = response.json()
+        assert manifest["policies_loaded"] == 3
+        assert {entry["name"] for entry in manifest["files"]} == {
+            "bad\\udcff.yaml",
+            "bad\\\\udcff.yaml",
+            "caf\\xe9.yaml",
+        }
+        assert all(
+            entry["content_sha256"] == hashlib.sha256(content).hexdigest()
+            for entry in manifest["files"]
+        )
+        reload = generation_client.post("/api/v1/policy/reload")
+        assert reload.status_code == 200
+        assert reload.json()["policy_set_id"] == manifest["policy_set_id"]
+        assert manifest["policy_set_id"] in caplog.text
+
+
+def test_serialization_failure_preserves_published_state(generation_client, tmp_path, monkeypatch):
+    from agentmesh.server import sidecar
+
+    previous = sidecar._policy_state
+    (tmp_path / "new.yaml").write_text("name: new\nrules: []\n", encoding="utf-8")
+
+    def fail_serialization(self, *args, **kwargs):
+        raise ValueError("manifest serialization failed")
+
+    monkeypatch.setattr(sidecar.PolicyLoadGeneration, "model_dump_json", fail_serialization)
+    with pytest.raises(ValueError, match="manifest serialization failed"):
+        generation_client.post("/api/v1/policy/reload")
+    assert sidecar._policy_state is previous
+    assert generation_client.get("/ready").json()["policy_set_id"] == previous[1].policy_set_id
+
+
 def test_evaluation_keeps_its_generation_when_reload_publishes(
     generation_client, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Problem and change

Closes #3562. Implements the policy-load provenance proposal by @halvrenofviryel.

A sidecar decision currently identifies at most its winning policy, not the policy set available for evaluation or any files rejected during loading. Build a fresh engine and immutable load manifest, publish them together, and return the captured generation's `policy_set_id` and `policy_set_status` with each decision.

The content-addressed manifest includes discovered YAML/JSON filenames, raw-byte hashes and load outcomes, including failures. Readiness/reload diagnostics expose file counts and status; the existing policy listing exposes the current manifest. INFO logs retain each completed manifest for deployments to archive. No raw policy content or exception messages enter the manifest. Identical manifests reuse the same ID. This does not change policy decisions, partial-loading permissiveness, or readiness HTTP status, and does not claim atomic filesystem discovery or signed attestation.

## Validation

- Sidecar, policy-schema, and rate-limit tests: 58 passed.
- Regressions cover mixed YAML/JSON success/failure, failed-content changes, missing vs empty directory, unreadable files, and reload during an in-flight decision.
- Targeted Ruff lint/format and `git diff --check`: passed.
- `python scripts/docs/check_links.py`: 0 new broken links.
- `python scripts/docs/check_frontmatter.py --strict`: 0 findings.
- Full agent-mesh suite on WSL/Python 3.11 with local sibling sources: 3,716 passed, 123 skipped. Optional integrations requiring unavailable services/backends account for skipped coverage; no claim is made about those paths.

## AI assistance

Codex prepared the implementation, tests, and this description under contributor direction. The contributor approved submission after receiving the exact commit diffs, review checklist, tradeoffs, and validation results.

## Type and scope

New feature and documentation update in agent-mesh.

## Timeline

None.
