### PR TITLE
fix(maf): preserve native execution identity in governance evidence

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -491,6 +491,7 @@ class AuditLog:
         policy_decision: Optional[str] = None,
         trace_id: Optional[str] = None,
         *,
+        session_id: str | None = None,
         arguments_hash: str | None = None,
         approver_did: str | None = None,
         policy_version: str | None = None,
@@ -499,7 +500,7 @@ class AuditLog:
     ) -> AuditEntry:
         """Log an audit event.
 
-        The ``arguments_hash``, ``approver_did``, ``policy_version``,
+        The ``session_id``, ``arguments_hash``, ``approver_did``, ``policy_version``,
         ``issued_at``, and ``completed_at`` parameters are accepted as
         keyword-only arguments to preserve the positional signature for
         existing callers. See spec §4.3.1 for semantics and the v1.0/v1.1
@@ -514,6 +515,7 @@ class AuditLog:
             outcome=outcome,
             policy_decision=policy_decision,
             trace_id=trace_id,
+            session_id=session_id,
             sandbox_id=self._env_context.sandbox_id,
             environment=self._env_context.environment,
             compute_driver=self._env_context.compute_driver,

--- a/agent-governance-python/agent-os/README.md
+++ b/agent-governance-python/agent-os/README.md
@@ -1146,6 +1146,36 @@ pytest
 
 ---
 
+## Microsoft Agent Framework execution identity
+
+`create_governance_middleware` creates one adapter-owned execution state shared by
+the runtime and capability middleware. Create a separate stack for each independent
+agent run; reusing a stack shares its session counters. Standalone middleware
+instances create independent unique execution IDs.
+
+The capability guard passes MAF's exact `context.metadata["call_id"]` to policy
+evaluation. Missing or invalid call IDs block before evaluation and tool execution.
+Native call/session identifiers must be non-empty printable ASCII strings of at
+most 256 characters and are preserved without normalization. A missing or invalid
+`context.session.session_id` is omitted from audit and does not block execution.
+Neither native identifier is an authenticated principal or a HostSession cache key.
+
+Capability deny/start/complete/error audit records carry native identifiers and
+available ACS input/enforced identities in hash-covered `data["correlation"]`.
+Terminal records reference their start entry even when the tool raises or is
+cancelled. Capability completion records omit raw result previews. The optional
+keyword-only `AuditLog.log(session_id=...)` argument also projects session identity
+into the existing query/CloudEvents field; this top-level field is outside the
+v1.0 hash, so the nested correlation object is the integrity-covered copy.
+
+Upgrade considerations: merging the two adapter sessions consolidates their
+accounting, so configured limits can be reached sooner. Native call IDs replace
+counter-derived policy inputs and change ACS action digests; finish in-flight
+approvals before upgrade or reissue them afterward. An ACS digest is not a stable
+retry/resume key because policy inputs also include timestamps and running budgets.
+This adapter mapping does not implement checkpoint correlation or attest that
+caller-supplied native identifiers are truthful.
+
 ## License
 
 MIT — See [LICENSE](LICENSE)

--- a/agent-governance-python/agent-os/src/agent_os/integrations/maf_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/maf_adapter.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import logging
 import time
+import uuid
 from typing import Any, Awaitable, Callable, Optional
 
 from ._native_adapter_runtime import (
@@ -66,6 +67,13 @@ except ImportError:
     RogueDetectorConfig = None  # type: ignore[assignment,misc]
 
 logger = logging.getLogger(__name__)
+
+
+def _native_identity(value: Any) -> str | None:
+    """Keep bounded native evidence verbatim; it is not an authenticated principal."""
+    if isinstance(value, str) and 0 < len(value) <= 256 and all(" " <= c <= "~" for c in value):
+        return value
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -257,7 +265,7 @@ class RuntimeGovernanceMiddleware(AgentMiddleware):
         if self._v5_ctx is None:
             self._v5_ctx = AdapterExecutionState(
                 agent_id=self._agent_id,
-                session_id=f"maf-mw-{int(time.time())}",
+                session_id=f"maf-mw-{uuid.uuid4().hex}",
             )
         return self._v5_ctx
 
@@ -424,7 +432,7 @@ class CapabilityGuardMiddleware(FunctionMiddleware):
         if self._v5_ctx is None:
             self._v5_ctx = AdapterExecutionState(
                 agent_id=self._agent_id,
-                session_id=f"maf-cap-{int(time.time())}",
+                session_id=f"maf-cap-{uuid.uuid4().hex}",
             )
         return self._v5_ctx
 
@@ -456,13 +464,39 @@ class CapabilityGuardMiddleware(FunctionMiddleware):
         else:
             args_dict = {"_value": raw_args}
 
+        metadata = getattr(context, "metadata", None)
+        call_id = _native_identity(metadata.get("call_id") if isinstance(metadata, dict) else None)
+        session_id = _native_identity(
+            getattr(getattr(context, "session", None), "session_id", None)
+        )
+        correlation = {"framework": "microsoft-agent-framework"}
+        if session_id is not None:
+            correlation["session_id"] = session_id
+        if call_id is None:
+            if self.audit_log:
+                self.audit_log.log(
+                    event_type="tool_blocked",
+                    agent_did="capability-guard",
+                    action="deny",
+                    resource=func_name,
+                    session_id=session_id,
+                    data={"reason": "invalid_framework_call_id", "correlation": correlation},
+                    outcome="denied",
+                )
+            raise MiddlewareTermination("MAF tool call requires a valid native call_id")
+        correlation["call_id"] = call_id
+
         ctx = self._ensure_v5_context()
         bridge_result = self.kernel.evaluate_pre_tool_call(
             ctx,
             tool_name=func_name,
             args=args_dict,
-            call_id=f"maf-cap-{ctx.call_count + 1}",
+            call_id=call_id,
         )
+        for name in ("input_identity", "enforced_identity"):
+            identity = getattr(bridge_result, name, None)
+            if isinstance(identity, str):
+                correlation[name] = identity
 
         if not bridge_result.allowed or not bridge_result.applies_to(dict):
             reason = bridge_result.reason or "tool_blocked"
@@ -472,9 +506,7 @@ class CapabilityGuardMiddleware(FunctionMiddleware):
                 reason,
             )
 
-            context.result = (
-                f"⛔ Tool '{func_name}' is not permitted by governance policy"
-            )
+            context.result = f"⛔ Tool '{func_name}' is not permitted by governance policy"
 
             if self.audit_log:
                 self.audit_log.log(
@@ -482,13 +514,12 @@ class CapabilityGuardMiddleware(FunctionMiddleware):
                     agent_did="capability-guard",
                     action="deny",
                     resource=func_name,
-                    data={"tool": func_name, "reason": reason},
+                    data={"tool": func_name, "reason": reason, "correlation": correlation},
+                    session_id=session_id,
                     outcome="denied",
                 )
 
-            raise MiddlewareTermination(
-                f"Tool '{func_name}' is not permitted by governance policy"
-            )
+            raise MiddlewareTermination(f"Tool '{func_name}' is not permitted by governance policy")
 
         # AGT-DELTA D1.1: rewrite the outbound arguments when the
         # engine returned a transform verdict so the next filter sees
@@ -499,18 +530,30 @@ class CapabilityGuardMiddleware(FunctionMiddleware):
             try:
                 context.arguments = bridge_result.transformed_value
             except Exception as exc:  # noqa: BLE001 — opaque context object
+                if self.audit_log:
+                    self.audit_log.log(
+                        event_type="tool_blocked",
+                        agent_did="capability-guard",
+                        action="deny",
+                        resource=func_name,
+                        session_id=session_id,
+                        data={"reason": "transform_not_applied", "correlation": correlation},
+                        outcome="denied",
+                    )
                 raise MiddlewareTermination(
                     "AGT returned a transform the capability guard could not "
                     "write to the tool arguments"
                 ) from exc
 
+        start_entry = None
         if self.audit_log:
-            self.audit_log.log(
+            start_entry = self.audit_log.log(
                 event_type="tool_invocation",
                 agent_did="capability-guard",
                 action="start",
                 resource=func_name,
-                data={"tool": func_name},
+                data={"tool": func_name, "correlation": correlation},
+                session_id=session_id,
                 outcome="success",
             )
 
@@ -519,24 +562,26 @@ class CapabilityGuardMiddleware(FunctionMiddleware):
             func_name,
         )
 
-        await call_next()
-
-        ctx.call_count += 1
-
-        # Log completion with a truncated result summary.
-        result_summary = str(getattr(context, "result", ""))[:500]
-        if self.audit_log:
-            self.audit_log.log(
-                event_type="tool_invocation",
-                agent_did="capability-guard",
-                action="complete",
-                resource=func_name,
-                data={
-                    "tool": func_name,
-                    "result_preview": result_summary,
-                },
-                outcome="success",
-            )
+        completed = False
+        try:
+            await call_next()
+            ctx.call_count += 1
+            completed = True
+        finally:
+            if self.audit_log:
+                self.audit_log.log(
+                    event_type="tool_invocation",
+                    agent_did="capability-guard",
+                    action="complete" if completed else "error",
+                    resource=func_name,
+                    data={
+                        "tool": func_name,
+                        "correlation": correlation,
+                        "start_entry_id": start_entry.entry_id,
+                    },
+                    session_id=session_id,
+                    outcome="success" if completed else "error",
+                )
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -765,14 +810,17 @@ def create_governance_middleware(
     stack: list[Any] = []
     if audit_log is not None:
         stack.append(AuditTrailMiddleware(audit_log=audit_log, agent_did=agent_id))
-    stack.extend([
-        RuntimeGovernanceMiddleware(
-            kernel=kernel, audit_log=audit_log, agent_id=agent_id
-        ),
-        CapabilityGuardMiddleware(
-            kernel=kernel, audit_log=audit_log, agent_id=agent_id
-        ),
-    ])
+    runtime_middleware = RuntimeGovernanceMiddleware(
+        kernel=kernel, audit_log=audit_log, agent_id=agent_id
+    )
+    capability_guard = CapabilityGuardMiddleware(
+        kernel=kernel, audit_log=audit_log, agent_id=agent_id
+    )
+    # One factory call owns one execution state; native session IDs remain audit-only.
+    runtime_middleware._v5_ctx = capability_guard._v5_ctx = AdapterExecutionState(
+        agent_id=agent_id, session_id=f"maf-{uuid.uuid4().hex}"
+    )
+    stack.extend([runtime_middleware, capability_guard])
     if enable_rogue_detection and RogueAgentDetector is not None:
         stack.append(
             RogueDetectionMiddleware(

--- a/agent-governance-python/agent-os/tests/test_maf_execution_identity.py
+++ b/agent-governance-python/agent-os/tests/test_maf_execution_identity.py
@@ -1,0 +1,190 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Native identity mapping and hash-covered MAF tool audit evidence."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from agentmesh.governance.audit import AuditLog
+
+from agent_os.integrations.maf_adapter import (
+    CapabilityGuardMiddleware,
+    MiddlewareTermination,
+    RuntimeGovernanceMiddleware,
+    create_governance_middleware,
+)
+
+
+def function_context(call_id="call-native", session_id="session-native"):
+    return SimpleNamespace(
+        function=SimpleNamespace(name="approve_invoice"),
+        arguments={"invoice_id": "sensitive-123"},
+        metadata={"call_id": call_id},
+        session=SimpleNamespace(session_id=session_id) if session_id is not None else None,
+        result="sensitive-result",
+    )
+
+
+@pytest.fixture
+def guard():
+    kernel = MagicMock()
+    kernel.evaluate_pre_tool_call.return_value = SimpleNamespace(
+        allowed=True,
+        applies_to=lambda kind: True,
+        transform=None,
+        input_identity="sha256:input",
+        enforced_identity="sha256:enforced",
+    )
+    return CapabilityGuardMiddleware(kernel=kernel, audit_log=AuditLog())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [None, RuntimeError, asyncio.CancelledError])
+async def test_tool_audit_preserves_native_identity_and_closes_start(guard, failure):
+    ctx = function_context()
+    call_next = AsyncMock(side_effect=failure("private-error") if failure else None)
+    if failure:
+        with pytest.raises(failure):
+            await guard.process(ctx, call_next)
+    else:
+        await guard.process(ctx, call_next)
+    assert guard.kernel.evaluate_pre_tool_call.call_args.kwargs["call_id"] == "call-native"
+    entries = guard.audit_log.get_entries_by_type("tool_invocation")
+    assert len(entries) == 2
+    start, terminal = entries
+    assert start.action == "start"
+    assert terminal.action == ("error" if failure else "complete")
+    assert terminal.data["start_entry_id"] == start.entry_id
+    assert (
+        terminal.data["correlation"]
+        == start.data["correlation"]
+        == {
+            "framework": "microsoft-agent-framework",
+            "call_id": "call-native",
+            "session_id": "session-native",
+            "input_identity": "sha256:input",
+            "enforced_identity": "sha256:enforced",
+        }
+    )
+    assert start.session_id == terminal.session_id == "session-native"
+    assert start.to_cloudevent()["sessionid"] == "session-native"
+    assert "sensitive" not in terminal.model_dump_json()
+    assert "private-error" not in terminal.model_dump_json()
+    assert guard.audit_log.verify_integrity()[0]
+    terminal.data["correlation"]["call_id"] = "tampered"
+    assert not guard.audit_log.verify_integrity()[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call_id", [None, "", 7, "a" * 257, "line\nbreak", "non-ascii-é"])
+async def test_invalid_call_identity_blocks_before_evaluation(guard, call_id):
+    call_next = AsyncMock()
+    with pytest.raises(MiddlewareTermination, match="native call_id"):
+        await guard.process(function_context(call_id=call_id), call_next)
+    call_next.assert_not_awaited()
+    guard.kernel.evaluate_pre_tool_call.assert_not_called()
+    entry = guard.audit_log.get_entries_by_type("tool_blocked")[0]
+    assert "call_id" not in entry.data["correlation"]
+    assert entry.outcome == "denied"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("session_id", [None, "", 42, "s" * 257, "bad\nvalue"])
+async def test_sessionless_or_invalid_session_does_not_block(guard, session_id):
+    call_next = AsyncMock()
+    # A valid boundary-length call ID is forwarded without normalization.
+    call_id = " " + "x" * 255
+    await guard.process(function_context(call_id, session_id), call_next)
+    call_next.assert_awaited_once()
+    assert guard.kernel.evaluate_pre_tool_call.call_args.kwargs["call_id"] == call_id
+    for entry in guard.audit_log.get_entries_by_type("tool_invocation"):
+        assert entry.session_id is None
+        assert "session_id" not in entry.data["correlation"]
+
+
+@pytest.mark.asyncio
+async def test_policy_denial_records_the_same_native_evidence(guard):
+    guard.kernel.evaluate_pre_tool_call.return_value.allowed = False
+    guard.kernel.evaluate_pre_tool_call.return_value.reason = "invoice_limit"
+    call_next = AsyncMock()
+    with pytest.raises(MiddlewareTermination):
+        await guard.process(function_context(), call_next)
+    call_next.assert_not_awaited()
+    entry = guard.audit_log.get_entries_by_type("tool_blocked")[0]
+    assert entry.data["correlation"]["call_id"] == "call-native"
+    assert entry.data["correlation"]["enforced_identity"] == "sha256:enforced"
+    assert entry.session_id == "session-native"
+    assert not guard.audit_log.get_entries_by_type("tool_invocation")
+
+
+def test_factory_shares_real_host_session_but_isolates_separate_runs():
+    def layers():
+        stack = create_governance_middleware(runtime=MagicMock(), enable_rogue_detection=False)
+        return (
+            next(m for m in stack if isinstance(m, RuntimeGovernanceMiddleware)),
+            next(m for m in stack if isinstance(m, CapabilityGuardMiddleware)),
+        )
+
+    runtime, capability = layers()
+    other_runtime, other_capability = layers()
+    first = runtime.kernel.bridge._session_for(runtime._ensure_v5_context())
+    same = capability.kernel.bridge._session_for(capability._ensure_v5_context())
+    other = other_capability.kernel.bridge._session_for(other_capability._ensure_v5_context())
+    assert first is same
+    assert first is not other
+    assert runtime._ensure_v5_context().session_id != other_runtime._ensure_v5_context().session_id
+    first.builder.record_tool_call()
+    assert same.builder.tool_call_count == 1
+    assert other.builder.tool_call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_transform_write_failure_records_correlated_denial(guard):
+    class ReadOnlyArguments:
+        function = SimpleNamespace(name="approve_invoice")
+        metadata = {"call_id": "call-transform"}
+        session = None
+
+        @property
+        def arguments(self):
+            return {"invoice_id": "original"}
+
+    result = guard.kernel.evaluate_pre_tool_call.return_value
+    result.transform = object()
+    result.transformed_value = {"invoice_id": "sanitized"}
+    call_next = AsyncMock()
+    with pytest.raises(MiddlewareTermination, match="write to the tool arguments"):
+        await guard.process(ReadOnlyArguments(), call_next)
+    call_next.assert_not_awaited()
+    entry = guard.audit_log.get_entries_by_type("tool_blocked")[0]
+    assert entry.data["reason"] == "transform_not_applied"
+    assert entry.data["correlation"]["call_id"] == "call-transform"
+    assert not guard.audit_log.get_entries_by_type("tool_invocation")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_keep_their_own_audit_correlation(guard):
+    entered = asyncio.Event()
+    count = 0
+
+    async def tool():
+        nonlocal count
+        count += 1
+        if count == 2:
+            entered.set()
+        await entered.wait()
+
+    await asyncio.gather(
+        guard.process(function_context("call-a", "session-a"), tool),
+        guard.process(function_context("call-b", "session-b"), tool),
+    )
+    entries = guard.audit_log.get_entries_by_type("tool_invocation")
+    assert len(entries) == 4
+    by_id = {entry.entry_id: entry for entry in entries}
+    for terminal in (entry for entry in entries if entry.action == "complete"):
+        start = by_id[terminal.data["start_entry_id"]]
+        assert start.data["correlation"] == terminal.data["correlation"]
+        assert start.session_id == terminal.session_id
+    assert guard.audit_log.verify_integrity()[0]

--- a/agent-governance-python/agt-policies/tests/scenarios/test_maf_adapter_scenarios.py
+++ b/agent-governance-python/agt-policies/tests/scenarios/test_maf_adapter_scenarios.py
@@ -135,6 +135,8 @@ def _make_function_ctx(
     return SimpleNamespace(
         function=SimpleNamespace(name=func_name),
         arguments=arguments if arguments is not None else {"query": "weather"},
+        metadata={"call_id": "maf-scenario-call"},
+        session=None,
         result=None,
     )
 
@@ -321,6 +323,7 @@ def test_capability_guard_transform_path_rewrites_arguments(tmp_path: Path) -> N
 
     # The wrapped tool MUST receive the AGT-redacted arguments.
     assert captured["args"] == {"query": "[SANITIZED]"}
+    assert _policy.invocations[0]["input"]["snapshot"]["tool_call"]["id"] == "maf-scenario-call"
 
 
 def test_policy_middleware_refuses_a_replacement_it_cannot_write(


### PR DESCRIPTION
## Problem and proposed change

Refs #3613. Implements the four-point proposal in section 6 of @dev404ai's RFC; the original investigation and design are theirs. The RFC cites the existing .NET ACS Agent Framework adapter as precedent for forwarding native call identity.

The Python MAF adapter substitutes counter-derived tool-call IDs and creates separate timestamp-derived sessions for runtime and capability middleware. Preserve the exact native call ID, share a unique adapter-owned execution state per middleware factory invocation, and record validated native call/session IDs plus available ACS identities in hash-covered audit correlation data. A keyword-only `AuditLog.log(session_id=...)` argument also fills the existing session field.

Tool start records receive a linked terminal record on success, exceptions, and cancellation. Correlation does not copy raw arguments or results, and capability completion no longer logs a result preview. Native identifiers remain untrusted evidence, not principals or cache keys. Sessionless invocations remain supported.

## Maintainer decisions before merge

This RFC has not yet been accepted, and its author offered to implement or review. Please confirm ownership and the implementation choices before advancing this draft:

- Missing/invalid native call IDs block before evaluation and tool execution. This is stricter than .NET's null fallback.
- One factory invocation shares accounting across runtime/capability middleware immediately; no warning-release migration has been added.
- Both native identifiers use the RFC's 256-character printable-ASCII bounds and are preserved verbatim.
- The only third-package change is updating the existing agt-policies MAF scenario fixture to supply the native metadata shape.

Existing approvals tied to counter-derived inputs must finish before upgrade or be reissued. Reusing a middleware stack shares accounting; independent runs should use separate factory invocations. Checkpoint correlation, accounting redesign, a generic correlation resolver, and signed provenance are outside this proposal.

## Validation

- Built the native ACS Python SDK from this checkout; installed CI's OPA 0.70.0 binary and verified its pinned SHA-256.
- Full Agent-OS suite, excluding the repository's documented `test_mcp_server.py` exclusion: 2,937 passed, 78 skipped.
- MAF identity, existing middleware, and native policy-dispatcher scenarios: 42 passed, no skips. The real dispatcher receives the native tool-call ID.
- Audit compatibility tests: 102 passed, 17 optional tests skipped.
- Regression control: four new assertions fail against the upstream MAF source, demonstrating substituted call IDs and separate HostSession objects; they pass with this change.
- Ruff E/F checks on changed Python files, full configured Ruff on the new test file, and `git diff --check`: passed. Existing files have pre-existing broader Ruff style findings; unrelated reformatting is excluded.
- Documentation link and strict frontmatter checks: passed.

## AI assistance

Codex prepared the implementation, tests, and this description under contributor direction. The contributor approved submission after receiving the exact commit diffs, review checklist, tradeoffs, and validation results.

## Type and scope

Bug fix with compatibility changes described above. Affects agent-os and agent-mesh; agt-policies changes only an existing test fixture.

## Timeline

None; draft pending maintainer decisions.
