### PR TITLE
fix: opa - use --stdin-input instead of --input /dev/stdin (Windows)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/opa.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/opa.py
@@ -222,7 +222,16 @@ class OPAEvaluator:
         """Run `opa eval` subprocess."""
         input_json = json.dumps(input_data)
 
-        cmd = ["opa", "eval", "--format", "json", "--v0-compatible", "--input", "/dev/stdin", "--data"]
+        # `--stdin-input` (not `--input /dev/stdin`) reads the input document
+        # from the process's actual stdin. `/dev/stdin` is a real special file
+        # on Linux/macOS, where this previously worked by coincidence, but it
+        # doesn't exist on Windows: every call failed with "open /dev/stdin:
+        # The system cannot find the path specified.", and because that
+        # failure is caught below and turned into an ordinary
+        # OPADecision(allowed=False, ...) rather than raised, every policy
+        # check silently came back denied on Windows, including cases that
+        # should have been allowed.
+        cmd = ["opa", "eval", "--format", "json", "--v0-compatible", "--stdin-input", "--data"]
 
         if self.rego_path:
             cmd.append(self.rego_path)


### PR DESCRIPTION
Fixes #3912.

OPAEvaluator's local CLI mode constructed `opa eval --input /dev/stdin` and piped the input JSON via subprocess.run(input=...). /dev/stdin is a real special file on Linux/macOS, so this happened to work there, but it doesn't exist on Windows: every call failed with

    opa eval failed: open /dev/stdin: The system cannot find the path specified.

Because _evaluate_opa_cli catches the non-zero opa eval exit and returns OPADecision(allowed=False, ...) rather than raising, this was worse than a crash: every policy check silently came back denied on Windows, including cases that should have been allowed - the project's own test_opa.py demonstrates this precisely, since it asserts allowed=True in several cases.

Confirmed both ways by actually running tests/test_opa.py on Windows with opa v1.20.2 on PATH:
- Before this change: 10 of 26 tests fail, every one an `assert ... allowed is True` on a policy that should have matched.
- After this change: 25 of 26 pass. The one remaining failure (test_evaluation_timing, asserting evaluation_ms < 100) is unrelated to this fix and pre-existing: opa eval's own subprocess-spawn cost is ~550-650ms on this machine regardless of the /dev/stdin bug, so that assertion looks environment-dependent rather than something this change touches.

Fix: opa eval has a dedicated, portable flag for exactly this - -I/--stdin-input, which reads the input document from the process's actual stdin rather than a file path. Swapping to it removes the platform dependency entirely.

## Related Issue
<!-- Link the issue this PR resolves, e.g. Fixes #123 or Closes #456. -->

> **If no related issue is linked above, you must complete "Problem & Solution", "Impact on Your Work", and "Alternatives Considered" below.**

## Problem & Solution
<!-- Required if no related issue is linked above. Provide both: -->
<!-- Problem: what is broken, missing, or needed today? -->
<!-- Solution: what does this PR change to address it? -->

## Impact on Your Work
<!-- Required if no related issue is linked above. -->
<!-- How does this change impact your work and what are you trying to achieve? What pain point or blocker prompted it? -->

## Timeline
<!-- If this is time-sensitive, when do you need it merged by? Write "None" if there's no specific deadline. -->

## Alternatives Considered
<!-- Required if no related issue is linked above. -->
<!-- What other approaches did you evaluate, and why did you choose this one? Write "None" if this was the only viable approach. -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
**Core & runtime:**
- [ ] agent-governance-toolkit-core
- [ ] agent-primitives
- [ ] agent-os
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-compliance

**Governance & security:**
- [ ] agent-mcp-governance
- [ ] agent-rag-governance
- [ ] agent-sandbox
- [ ] agent-discovery
- [ ] agt-policies
- [ ] policy-engine

**Platform & tooling:**
- [ ] agent-hypervisor
- [ ] agent-lightning
- [ ] agent-marketplace
- [ ] agent-governance-toolkit-cli
- [ ] agent-governance-toolkit-integrations
- [ ] agent-governance-toolkit-protocols
- [ ] agentmesh-integrations (framework integrations)

**CLI plugins:**
- [ ] agent-governance CLI plugins (copilot-cli / claude-code / opencode / antigravity-cli)

**Shared / other:**
- [ ] schemas
- [ ] action (GitHub Action)
- [ ] examples
- [ ] docs / root

## Testing
<!-- Describe how you verified this change. -->

### Unit Testing
<!-- What unit tests did you add or update, and what do they cover? -->

### Manual Testing
<!-- What did you run by hand to verify this change (commands, environment, results)? -->
<!-- Write "N/A" if manual testing does not apply. -->

## Checklist
- [x] I have linked a related issue above, or completed "Problem & Solution", "Impact on Your Work", and "Alternatives Considered"
- [x] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
<!-- REQUIRED for new features, integrations, or architectural patterns -->
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [ ] Any external projects that inspired this design are credited in code comments or documentation
- [ ] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
<!-- Example: "Sandboxing approach inspired by https://github.com/example/project (Apache-2.0)" -->
<!-- Leave blank if not applicable -->

## AI Assistance
<!-- See CONTRIBUTING.md "AI-Assisted Contributions" for full policy -->
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [ ] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
<!-- Example: "GitHub Copilot for boilerplate, Codex for test generation — all output reviewed" -->
<!-- Leave blank if AI was not used or was only used for minor assistance -->

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License
