### PR TITLE
ci: bump typing-extensions test pin to 4.16.0

### DIFF
--- a/agent-governance-python/requirements/ci-test.txt
+++ b/agent-governance-python/requirements/ci-test.txt
@@ -17,8 +17,11 @@ pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
 # pytest-asyncio transitive dependencies (needed on Python <3.13)
-typing-extensions==4.15.0 \
-    --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
+# anyio>=4.15 (pulled in by fastapi/httpx) imports typing_extensions.sentinel,
+# which exists only from 4.16.0; an older pin here downgrades it after the
+# package install and breaks every agent-os/agent-mesh test collection.
+typing-extensions==4.16.0 \
+    --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
 # PyYAML — imported by tests/ci/test_regression_a2_toolkit_regex.py
 # (introduced in PR #2654). Workflow-lint job runs `pytest tests/ci/ -v`
 # after installing only this requirements file. Without PyYAML pinned


### PR DESCRIPTION
## Related Issue
None. Splits the one-line CI fix out of #3919 so it can land on its own.

## Problem & Solution
Problem: CI on `main` has failed `test (agent-os, 3.11–3.13)` and `test (agent-mesh, 3.11–3.13)` on every run since 2026-09-08. anyio 4.15.0 (released 2026-09-02) imports `typing_extensions.sentinel`, which exists only from typing-extensions 4.16.0. The test jobs install the package (resolving 4.16.0) and then install `requirements/ci-test.txt`, whose `typing-extensions==4.15.0` pin downgrades it. Every test module that imports fastapi fails at collection:

```
ImportError: cannot import name 'sentinel' from 'typing_extensions'
```

Solution: raise the pin to 4.16.0 with the PyPI wheel hash, and leave a comment explaining the constraint.

## Impact on Your Work
Unblocks CI for every open PR and for the dependabot lane (15 routine PRs are held only by this failure).

## Timeline
None

## Alternatives Considered
Pin `anyio<4.15` in agent-os and agent-mesh: rejected, it caps a runtime dependency to work around a test-only constraints file.

## Type of Change
- [x] Maintenance (dependency updates, CI/CD, refactoring)

## Package(s) Affected
- [x] docs / root

## Testing
### Unit Testing
N/A, pin change only.

### Manual Testing
- `pip install --require-hashes -r agent-governance-python/requirements/ci-test.txt` into a scratch target installs 4.16.0 and `typing_extensions.sentinel` resolves.
- anyio 4.15.1 with typing-extensions 4.16.0: `import anyio.abc` succeeds.
- Hash matches the PyPI-published digest for `typing_extensions-4.16.0-py3-none-any.whl`.

## Checklist
- [x] I have linked a related issue above, or completed "Problem & Solution", "Impact on Your Work", and "Alternatives Considered"
- [x] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License